### PR TITLE
Port to QRhi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,9 @@ jobs:
           - Release
         include:
         - qt_tools: tools_ninja
-          qt_modules:
+          qt_modules: qtshadertools
           cmake_cli_arg: 'OFF'
+          use_rhi: true
         - os: ubuntu-latest
           package_extension: 'tar.xz'
           package_suffix: 'linux_x64'
@@ -49,13 +50,13 @@ jobs:
           package_suffix: 'win_x64'
           win_arch: "x64"
           qt_arch: win64_msvc2022_64
-          qt_tools: tools_ninja, tools_cmake
+          qt_tools: tools_ninja tools_cmake
         - os: windows-11-arm
           package_extension: 'zip'
           package_suffix: 'win_arm64'
           win_arch: "arm64"
           qt_arch: win64_msvc2022_arm64
-          qt_tools: tools_ninja, tools_cmake
+          qt_tools: tools_ninja tools_cmake
         - interface: gui
           cmake_cli_arg: 'OFF'
           cmake_gui_arg: 'ON'
@@ -71,7 +72,6 @@ jobs:
       CMAKE_GENERATOR: Ninja
       CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
       VCPKG_KEEP_ENV_VARS: PATH
-
 
     steps:
     - uses: actions/checkout@v4
@@ -93,18 +93,22 @@ jobs:
         cp arm64-osx.cmake universal-osx.cmake
         sed -i '' 's|set(VCPKG_OSX_ARCHITECTURES arm64)|set(VCPKG_OSX_ARCHITECTURES "arm64;x86_64")|' universal-osx.cmake
 
-    - name: Setup NuGet.exe
-      uses: nuget/setup-nuget@v2
-      if: runner.os == 'Linux'
-      with:
-        nuget-version: latest
-
-    - name: Install Mono
-      shell: bash
+    - name: Install Mono (Linux)
       if: runner.os == 'Linux'
       run: |
-        sudo apt install mono-runtime
-        sudo apt install mono-complete
+        sudo apt-get update
+        sudo apt-get install -y mono-runtime mono-complete
+
+    - name: Install Mono (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew update
+        brew install mono
+
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v2
+      with:
+        nuget-version: latest
 
     - name: Enable vcpkg Github packages registry
       shell: bash
@@ -160,7 +164,7 @@ jobs:
     - name: Build Deling
       id: main_build
       run: |
-        cmake -B ${{ env.deling_build_path }} --preset ${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ env.deling_installation_path }} -DCLI:BOOL=${{ matrix.cmake_cli_arg }} -DGUI:BOOL=${{ matrix.cmake_gui_arg }} -DPRERELEASE_STRING="$PRERELEASE_STRING" ${{ matrix.cmake_extra_args }}
+        cmake -B ${{ env.deling_build_path }} --preset ${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ env.deling_installation_path }} -DCLI:BOOL=${{ matrix.cmake_cli_arg }} -DGUI:BOOL=${{ matrix.cmake_gui_arg }} -DRHI:BOOL=${{ matrix.use_rhi }} -DPRERELEASE_STRING="$PRERELEASE_STRING" ${{ matrix.cmake_extra_args }}
         cmake --build ${{ env.deling_build_path }} --target package -j3
 
     - name: Upload vcpkg build logs
@@ -220,7 +224,7 @@ jobs:
 
     - name: Setup NuGet.exe
       uses: nuget/setup-nuget@v2
-      if: runner.os == 'Linux'
+      if: runner.os != 'Windows'
       with:
         nuget-version: latest
 
@@ -245,7 +249,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake -S. -Bbuild --preset=Release -DCMAKE_INSTALL_PREFIX=/usr -DCPACK_DEBIAN_PACKAGE_RELEASE=${{github.run_attempt}}~${{matrix.config.name}}
+        cmake -S. -Bbuild --preset=Release -DRHI=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCPACK_DEBIAN_PACKAGE_RELEASE=${{github.run_attempt}}~${{matrix.config.name}}
         cmake --build build
         cpack -G DEB -C Release --config build/CPackConfig.cmake
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,16 @@ jobs:
         interface:
           - cli
           - gui
-        build_type:
-          - Release
         include:
         - qt_tools: tools_ninja
           qt_modules: qtshadertools
           cmake_cli_arg: 'OFF'
           use_rhi: true
+          build_type: 'Release'
         - os: ubuntu-latest
           package_extension: 'tar.xz'
           package_suffix: 'linux_x64'
+          build_type: 'Debug'
         - os: ubuntu-24.04-arm
           package_extension: 'tar.xz'
           package_suffix: 'linux_arm64'
@@ -51,6 +51,7 @@ jobs:
           win_arch: "x64"
           qt_arch: win64_msvc2022_64
           qt_tools: tools_ninja tools_cmake
+          build_type: 'Debug'
         - os: windows-11-arm
           package_extension: 'zip'
           package_suffix: 'win_arm64'
@@ -161,7 +162,7 @@ jobs:
         mv linuxdeploy-plugin-qt-*.AppImage $QT_ROOT_DIR/bin/linuxdeploy-plugin-qt
         mv linuxdeploy-*.AppImage $QT_ROOT_DIR/bin/linuxdeploy
 
-    - name: Build Deling
+    - name: Build Deling (${{ matrix.build_type }})
       id: main_build
       run: |
         cmake -B ${{ env.deling_build_path }} --preset ${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ env.deling_installation_path }} -DCLI:BOOL=${{ matrix.cmake_cli_arg }} -DGUI:BOOL=${{ matrix.cmake_gui_arg }} -DRHI:BOOL=${{ matrix.use_rhi }} -DPRERELEASE_STRING="$PRERELEASE_STRING" ${{ matrix.cmake_extra_args }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ project("Deling" VERSION 1.0.0 LANGUAGES CXX
 include(qt.cmake)
 
 # specify the C++ standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
@@ -59,6 +59,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 option(GUI "Build the gui executable" ON)
 option(CLI "Build the cli executable" OFF)
+option(RHI "Use Rhi instead of OpenGL" ON)
+
+# If ccache is found, use it
+find_program(CCACHE_FOUND ccache)
+if (CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    message(STATUS "Using ccache")
+endif ()
 
 add_compile_definitions(
     QT_DISABLE_DEPRECATED_UP_TO=0x060000
@@ -74,7 +82,19 @@ add_compile_definitions(
     DELING_VERSION_TWEAK=0
 )
 
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets OpenGLWidgets OpenGL LinguistTools REQUIRED)
+if (RHI)
+    find_package(
+      Qt${QT_VERSION_MAJOR}
+      COMPONENTS Core ShaderTools Widgets Gui LinguistTools
+      REQUIRED)
+else()
+    message(STATUS "Will use legacy QOpenGLWidgets")
+    find_package(
+      Qt${QT_VERSION_MAJOR}
+      COMPONENTS Core Widgets OpenGLWidgets OpenGL LinguistTools Gui
+      REQUIRED)
+    add_compile_definitions(USE_OPENGL)
+endif()
 find_package(ZLIB REQUIRED)
 find_package(lz4 CONFIG REQUIRED)
 
@@ -297,17 +317,37 @@ set(PROJECT_SOURCES
     "src/widgets/TdwWidget.h"
     "src/widgets/TdwWidget2.cpp"
     "src/widgets/TdwWidget2.h"
-    "src/widgets/WalkmeshWidget.cpp"
-    "src/widgets/WalkmeshWidget.h"
-    "src/widgets/WorldmapWidget.cpp"
-    "src/widgets/WorldmapWidget.h"
-    "src/3d/Renderer.cpp"
-    "src/3d/Renderer.h"
+)
+set(PROJECT_SOURCES_WIDGETS_GL
+    "src/widgets/gl/WalkmeshWidget.cpp"
+    "src/widgets/gl/WalkmeshWidget.h"
+    "src/widgets/gl/WorldmapWidget.cpp"
+    "src/widgets/gl/WorldmapWidget.h"
     "src/3d/WalkmeshGLWidget.cpp"
     "src/3d/WalkmeshGLWidget.h"
     "src/3d/WorldmapGLWidget.cpp"
     "src/3d/WorldmapGLWidget.h"
+    "src/3d/Renderer.cpp"
+    "src/3d/Renderer.h"
 )
+set(PROJECT_SOURCES_WIDGETS
+    "src/widgets/WalkmeshWidget.cpp"
+    "src/widgets/WorldmapWidget.cpp"
+    "src/widgets/WalkmeshRenderWidget.cpp"
+    "src/widgets/WalkmeshRenderWidget.h"
+    "src/widgets/WorldmapRenderWidget.cpp"
+    "src/widgets/WorldmapRenderWidget.h"
+)
+
+set(PROJECT_SOURCES_SHADERS
+    "src/qt/shaders/walkmesh.vert"
+    "src/qt/shaders/walkmesh.frag"
+    "src/qt/shaders/background.vert"
+    "src/qt/shaders/background.frag"
+    "src/qt/shaders/worldmap.vert"
+    "src/qt/shaders/worldmap.frag"
+)
+
 
 if(APPLE)
     list(APPEND PROJECT_SOURCES
@@ -460,6 +500,11 @@ set(PROJECT_CLI_SOURCES
     "src/Vertex.h"
 )
 
+if(RHI)
+    list(APPEND PROJECT_SOURCES ${PROJECT_SOURCES_WIDGETS})
+else()
+    list(APPEND PROJECT_SOURCES ${PROJECT_SOURCES_WIDGETS_GL})
+endif()
 set(RESOURCES "src/qt/${RELEASE_NAME}.qrc")
 
 if(APPLE)
@@ -475,15 +520,32 @@ elseif (WIN32)
 endif()
 
 if(GUI)
-	qt_add_executable(${GUI_TARGET} MANUAL_FINALIZATION MACOSX_BUNDLE WIN32 ${PROJECT_SOURCES} ${QM_FILES} ${RESOURCES} ${EXTRA_RESOURCES_GUI})
-	target_include_directories(${GUI_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/src")
-	target_link_libraries(${GUI_TARGET} PRIVATE
-		Qt::OpenGL
-		Qt::Widgets
-		Qt::OpenGLWidgets
-		ZLIB::ZLIB
-		lz4::lz4
-	)
+    qt_add_executable(${GUI_TARGET} MANUAL_FINALIZATION MACOSX_BUNDLE WIN32 ${PROJECT_SOURCES} ${QM_FILES} ${RESOURCES} ${EXTRA_RESOURCES_GUI})
+    target_include_directories(${GUI_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/src")
+    if(RHI)
+        target_link_libraries(${GUI_TARGET} PRIVATE
+            Qt6::Core
+            Qt6::Widgets
+            ZLIB::ZLIB
+            Qt6::Gui
+            lz4::lz4
+            Qt6::GuiPrivate
+            Qt6::ShaderTools
+            Qt6::ShaderToolsPrivate
+        )
+        qt_add_shaders(${GUI_TARGET} "deling_shaders"
+            FILES ${PROJECT_SOURCES_SHADERS}
+        )
+    else()
+        target_link_libraries(${GUI_TARGET} PRIVATE
+            Qt6::Core
+            Qt6::OpenGL
+            Qt6::Widgets
+            Qt6::OpenGLWidgets
+            ZLIB::ZLIB
+            lz4::lz4
+        )
+    endif()
 
 	if(${QT_VERSION_MAJOR} EQUAL 6)
 		target_compile_definitions(${GUI_TARGET}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,24 +524,24 @@ if(GUI)
     target_include_directories(${GUI_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/src")
     if(RHI)
         target_link_libraries(${GUI_TARGET} PRIVATE
-            Qt6::Core
-            Qt6::Widgets
+            Qt${QT_VERSION_MAJOR}::Core
+            Qt${QT_VERSION_MAJOR}::Widgets
             ZLIB::ZLIB
-            Qt6::Gui
+            Qt${QT_VERSION_MAJOR}::Gui
             lz4::lz4
-            Qt6::GuiPrivate
-            Qt6::ShaderTools
-            Qt6::ShaderToolsPrivate
+            Qt${QT_VERSION_MAJOR}::GuiPrivate
+            Qt${QT_VERSION_MAJOR}::ShaderTools
+            Qt${QT_VERSION_MAJOR}::ShaderToolsPrivate
         )
         qt_add_shaders(${GUI_TARGET} "deling_shaders"
             FILES ${PROJECT_SOURCES_SHADERS}
         )
     else()
         target_link_libraries(${GUI_TARGET} PRIVATE
-            Qt6::Core
-            Qt6::OpenGL
-            Qt6::Widgets
-            Qt6::OpenGLWidgets
+            Qt${QT_VERSION_MAJOR}::Core
+            Qt${QT_VERSION_MAJOR}::OpenGL
+            Qt${QT_VERSION_MAJOR}::Widgets
+            Qt${QT_VERSION_MAJOR}::OpenGLWidgets
             ZLIB::ZLIB
             lz4::lz4
         )
@@ -583,7 +583,7 @@ if(CLI)
     qt_add_executable(${CLI_TARGET} MANUAL_FINALIZATION ${PROJECT_CLI_SOURCES} ${RESOURCES} ${EXTRA_RESOURCES_CLI})
     target_include_directories(${CLI_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(${CLI_TARGET} PRIVATE
-        Qt::Gui
+        Qt${QT_VERSION_MAJOR}::Gui
         ZLIB::ZLIB
         lz4::lz4
     )

--- a/src/3d/Renderer.cpp
+++ b/src/3d/Renderer.cpp
@@ -26,13 +26,17 @@ size_t vectorSizeOf(const typename std::vector<T>& vec)
   return sizeof(T) * vec.size();
 }
 
-Renderer::Renderer(QOpenGLWidget *_widget) :
-    mProgram(_widget), mVertexShader(QOpenGLShader::Vertex, _widget), mFragmentShader(QOpenGLShader::Fragment, _widget),
-    mVAO(this), mVertex(QOpenGLBuffer::VertexBuffer), mIndex(QOpenGLBuffer::IndexBuffer),
-    mTexture(QOpenGLTexture::Target2D), _hasError(false), _buffersHaveChanged(true)
+Renderer::Renderer(QOpenGLWidget *_widget)
+    : mProgram(_widget), mVertexShader(QOpenGLShader::Vertex, _widget),
+      mFragmentShader(QOpenGLShader::Fragment, _widget), mVAO(this),
+      mVertex(QOpenGLBuffer::VertexBuffer), mIndex(QOpenGLBuffer::IndexBuffer),
+      mTexture(QOpenGLTexture::Target2D), _hasError(false)
 #ifdef QT_DEBUG
-    , mLogger(_widget)
+      ,
+      mLogger(_widget)
 #endif
+      ,
+      _buffersHaveChanged(true)
 {
 	mWidget = _widget;
 

--- a/src/3d/WorldmapGLWidget.cpp
+++ b/src/3d/WorldmapGLWidget.cpp
@@ -335,6 +335,7 @@ void WorldmapGLWidget::mousePressEvent(QMouseEvent *event)
 
 void WorldmapGLWidget::mouseReleaseEvent(QMouseEvent *event)
 {
+	Q_UNUSED(event);
 	_moveStart = QPointF();
 }
 

--- a/src/LZS.cpp
+++ b/src/LZS.cpp
@@ -51,7 +51,7 @@ const QByteArray &LZS::decompress(const char *data, int fileSize, int max)
 	if (result.capacity() < sizeAlloc) {
 		try {
 			result.reserve(sizeAlloc);
-		} catch (std::bad_alloc) {
+		} catch (const std::bad_alloc&) {
 			result.clear();
 			return result;
 		}

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -762,8 +762,8 @@ QString MainWindow::savePath() const
 void MainWindow::saveAs(const QString &optPath)
 {
 	QString filter, path = optPath;
-	
-	if (fieldArchive != nullptr || field != nullptr && field->isOpen() && field->isPc()) {
+
+	if (fieldArchive != nullptr || (field != nullptr && field->isOpen() && field->isPc())) {
 		filter = tr("FS Archive (*.fs)");
 	} else if (msdFile != nullptr) {
 		filter = tr("FF8 text files (*.msd)");

--- a/src/files/InfFile.h
+++ b/src/files/InfFile.h
@@ -62,6 +62,12 @@ public:
 	inline QString filterText() const {
 		return QObject::tr("Field gate and doors PC File (*.inf)");
 	}
+	inline int gatewayCount() const {
+		return this->getGateways().count();
+	}
+	inline int triggerCount(bool filter = true) const {
+		return this->getTriggers(filter).count();
+	}
     QString getMapName() const;
 	void setMapName(const QString &mapName);
 	quint8 controlDirection() const;

--- a/src/files/TdwFile.cpp
+++ b/src/files/TdwFile.cpp
@@ -268,7 +268,8 @@ uint TdwFile::letterPixelIndex(int charId, const QPoint &pos) const
 
 	if (isOptimizedVersion()) {
 		// returns a number between 0 and 3
-		const QRgb &color = _tim.colorTable(charId % 2).at(index);
+		const QVector<QRgb> colorTable = _tim.colorTable(charId % 2);
+		const QRgb &color = colorTable.at(index);
 
 		return _tim.colorTable(0).indexOf(color);
 	} else {
@@ -291,7 +292,8 @@ bool TdwFile::setLetterPixelIndex(int charId, const QPoint &pos, uint pixelIndex
 		notModifColorTable = _tim.colorTable((charId + 1) % 2);
 		uint realPixelIndex = _tim.imagePtr()->pixelIndex(letterPos(charId) + pos);
 
-		const QRgb &newColor = _tim.colorTable(0).at(pixelIndex % 4);
+		const QVector<QRgb> colorTable0 = _tim.colorTable(0);
+		const QRgb &newColor = colorTable0.at(pixelIndex % 4);
 		const QRgb &notModifColor = notModifColorTable.at(realPixelIndex);
 		int index = -1;
 

--- a/src/files/TexFile.cpp
+++ b/src/files/TexFile.cpp
@@ -125,7 +125,7 @@ void TexFile::setVersion(Version version)
 	header.version = int(version);
 }
 
-void TexFile::updateHeader()
+void TexFile::updateHeader() const
 {
 	header.nbPalettes = _colorTables.size();
 	header.hasPal = !_colorTables.isEmpty();
@@ -134,7 +134,7 @@ void TexFile::updateHeader()
 	header.hasColorKeyArray = !colorKeyArray.isEmpty();
 }
 
-bool TexFile::save(QByteArray &data)
+bool TexFile::save(QByteArray &data) const
 {
 	updateHeader();
 	data.append((char *)&header, header.version==2 ? sizeof(TexStruct) : sizeof(TexStruct) - 4);

--- a/src/files/TexFile.h
+++ b/src/files/TexFile.h
@@ -98,13 +98,13 @@ public:
 	TexFile(const TextureFile &textureFile, const TexStruct &header,
 			const QVector<quint8> &colorKeyArray=QVector<quint8>());
 	virtual bool open(const QByteArray &data);
-	virtual bool save(QByteArray &data);
+	virtual bool save(QByteArray &data) const;
 	TexFile scaled(const QSize &size) const;
 	void setVersion(Version version);
 	void debug();
 private:
-	void updateHeader();
-	TexStruct header;
+	void updateHeader() const;
+	mutable TexStruct header;
 	QVector<quint8> colorKeyArray;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
 	format.setVersion(4, 1);
 #ifdef QT_DEBUG
 	format.setOption(QSurfaceFormat::DebugContext);
+	QLoggingCategory::setFilterRules("*.debug=true\n"
+	                                 "qt.rhi.general=true");
+
 #endif
 	QSurfaceFormat::setDefaultFormat(format);
 

--- a/src/qt/shaders/background.frag
+++ b/src/qt/shaders/background.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location = 0) in vec2 vUv;
+layout(location = 0) out vec4 outFragColor;
+
+layout(binding = 1) uniform sampler2D uTex;
+
+void main()
+{
+    vec4 t = texture(uTex, vUv);
+    outFragColor = vec4(t.b, t.g, t.r, t.a);
+}

--- a/src/qt/shaders/background.vert
+++ b/src/qt/shaders/background.vert
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location = 0) in vec2 inPos;
+layout(location = 1) in vec2 inUv;
+
+layout(location = 0) out vec2 vUv;
+
+void main()
+{
+    vUv = inUv;
+    gl_Position = vec4(inPos.xy, 0.0, 1.0);
+}

--- a/src/qt/shaders/walkmesh.frag
+++ b/src/qt/shaders/walkmesh.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) in vec3 vColor;
+layout(location = 0) out vec4 outFragColor;
+
+void main()
+{
+    outFragColor = vec4(vColor, 1.0);
+}

--- a/src/qt/shaders/walkmesh.vert
+++ b/src/qt/shaders/walkmesh.vert
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inColor;
+
+layout(location = 0) out vec3 vColor;
+
+layout(std140, binding = 0) uniform Ubo {
+    mat4 mvp;
+};
+
+void main()
+{
+    vColor = inColor;
+    gl_Position = mvp * vec4(inPosition, 1.0);
+}

--- a/src/qt/shaders/worldmap.frag
+++ b/src/qt/shaders/worldmap.frag
@@ -1,0 +1,6 @@
+#version 440
+layout(location = 0) in vec3 v_color;
+layout(location = 0) out vec4 fragColor;
+void main() {
+    fragColor = vec4(v_color, 1.0);
+}

--- a/src/qt/shaders/worldmap.vert
+++ b/src/qt/shaders/worldmap.vert
@@ -1,0 +1,11 @@
+#version 440
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 color;
+layout(std140, binding = 0) uniform Transform {
+    mat4 mvp;
+};
+layout(location = 0) out vec3 v_color;
+void main() {
+    v_color = color;
+    gl_Position = mvp * vec4(position, 1.0);
+}

--- a/src/widgets/JsmWidget.cpp
+++ b/src/widgets/JsmWidget.cpp
@@ -16,7 +16,11 @@
  ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
  ****************************************************************************/
 #include "widgets/JsmWidget.h"
+#ifdef USE_OPENGL
 #include "3d/WalkmeshGLWidget.h"
+#else
+#include "WalkmeshRenderWidget.h"
+#endif
 #include "Config.h"
 #include "Data.h"
 
@@ -391,7 +395,12 @@ void JsmWidget::showPreview(const QString &line, QPoint cursorPos)
 		vertex[1].y = qint16(texts.at(5).toInt());
 		vertex[1].z = qint16(texts.at(6).toInt());
 
+#ifdef USE_OPENGL
 		WalkmeshGLWidget walkmeshWidget;
+#else
+		WalkmeshRenderWidget walkmeshWidget;
+#endif
+
 		walkmeshWidget.hide();
 		walkmeshWidget.fill(data());
 		walkmeshWidget.setLineToDraw(vertex);

--- a/src/widgets/Q3DWidget.h
+++ b/src/widgets/Q3DWidget.h
@@ -2,7 +2,6 @@
 #define Q3DWIDGET_H
 
 #include <QWidget>
-#include <QtGui/private/qrhi_p.h>
 
 class Q3DWidget : public QWidget
 {

--- a/src/widgets/WalkmeshRenderWidget.cpp
+++ b/src/widgets/WalkmeshRenderWidget.cpp
@@ -1,0 +1,879 @@
+/****************************************************************************
+ * * Deling QRhi port
+ ** Copyright (C) 2025 Alexandre 'kidev' Poumaroux <public@kidev.org>
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+
+#include "WalkmeshRenderWidget.h"
+#include <QMatrix4x4>
+#include <QKeyEvent>
+
+// Helper to load a QShader from resource
+static QShader loadShader(const QString &name)
+{
+	QFile f(name);
+	if (!f.open(QIODevice::ReadOnly)) {
+		qWarning("Failed to open shader file %s", qPrintable(name));
+		return QShader();
+	}
+	return QShader::fromSerialized(f.readAll());
+}
+
+void WalkmeshRenderWidget::rebuildBackgroundResources(QRhiCommandBuffer *cb)
+{
+	// Destroy previous bg texture/SRB
+	m_bgTexture.reset();
+	m_bgSrb.reset();
+
+	QRhiResourceUpdateBatch *rub = m_rhi->nextResourceUpdateBatch();
+
+	if (!m_bgImage.isNull()) {
+		// Create a texture from the actual background image
+		m_bgTexture.reset(m_rhi->newTexture(
+		    QRhiTexture::RGBA8, m_bgImage.size(), 1,
+		    QRhiTexture::MipMapped | QRhiTexture::UsedAsTransferSource));
+		m_bgTexture->create();
+		rub->uploadTexture(m_bgTexture.get(), m_bgImage);
+	} else {
+		// Create a 1x1 fallback texture (black) so SRB is never null
+		QImage dummy(1, 1, QImage::Format_RGBA8888);
+		dummy.fill(Qt::black);
+		m_bgTexture.reset(m_rhi->newTexture(QRhiTexture::RGBA8, dummy.size(), 1,
+		                                    QRhiTexture::UsedAsTransferSource));
+		m_bgTexture->create();
+		rub->uploadTexture(m_bgTexture.get(), dummy);
+	}
+
+	// Ensure we have a sampler
+	if (!m_bgSampler) {
+		m_bgSampler.reset(m_rhi->newSampler(
+		    QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
+		    QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge));
+		m_bgSampler->create();
+	}
+
+	// Create SRB with sampler at binding 1
+	m_bgSrb.reset(m_rhi->newShaderResourceBindings());
+	m_bgSrb->setBindings({ QRhiShaderResourceBinding::sampledTexture(
+	    1, QRhiShaderResourceBinding::FragmentStage, m_bgTexture.get(),
+	    m_bgSampler.get()) });
+	m_bgSrb->create();
+
+	cb->resourceUpdate(rub);
+
+	m_bgDirty = false;
+}
+
+WalkmeshRenderWidget::WalkmeshRenderWidget(QWidget *parent) : QRhiWidget(parent)
+{
+	setFocusPolicy(
+	    Qt::StrongFocus); // to receive key events, hopefully before the tabs
+}
+
+WalkmeshRenderWidget::~WalkmeshRenderWidget()
+{
+	this->resetResources();
+}
+
+void WalkmeshRenderWidget::setXRotation(int angle)
+{
+	angle %= 360;
+	if (angle < 0)
+		angle += 360;
+	if (qFuzzyCompare(m_xRot, float(angle)))
+		return;
+	m_xRot = float(angle);
+	update();
+}
+
+void WalkmeshRenderWidget::setYRotation(int angle)
+{
+	angle %= 360;
+	if (angle < 0)
+		angle += 360;
+	if (qFuzzyCompare(m_yRot, float(angle)))
+		return;
+	m_yRot = float(angle);
+	update();
+}
+
+void WalkmeshRenderWidget::setZRotation(int angle)
+{
+	angle %= 360;
+	if (angle < 0)
+		angle += 360;
+	if (qFuzzyCompare(m_zRot, float(angle)))
+		return;
+	m_zRot = float(angle);
+	update();
+}
+
+void WalkmeshRenderWidget::setCurrentTabIndex(int index)
+{
+	_selectedTabIndex = index;
+	update();
+}
+
+void WalkmeshRenderWidget::resetCamera()
+{
+	m_xRot = m_yRot = m_zRot = 0.0f;
+	m_xTrans = m_yTrans = 0.0f;
+	update();
+}
+
+void WalkmeshRenderWidget::setBackgroundVisible(bool show)
+{
+	m_backgroundVisible = show;
+	update();
+}
+
+void WalkmeshRenderWidget::clear()
+{
+	m_fieldData = nullptr;
+	m_bgImage = QImage();
+	_drawLine = false;
+	update();
+}
+
+void WalkmeshRenderWidget::setSelectedTriangle(int triangle)
+{
+	_selectedTriangle = triangle;
+	update();
+}
+
+void WalkmeshRenderWidget::setSelectedDoor(int door)
+{
+	_selectedDoor = door;
+	update();
+}
+
+void WalkmeshRenderWidget::setSelectedGate(int gate)
+{
+	_selectedGate = gate;
+	update();
+}
+
+void WalkmeshRenderWidget::setLineToDraw(const Vertex vertex[2])
+{
+	_lineToDrawPoint1 = vertex[0];
+	_lineToDrawPoint2 = vertex[1];
+	_drawLine = true;
+	update();
+}
+
+void WalkmeshRenderWidget::fill(Field *data)
+{
+	m_fieldData = data;
+
+	// Load background image
+	if (m_fieldData && m_fieldData->getBackgroundFile()) {
+		m_bgImage = m_fieldData->getBackgroundFile()->background();
+	} else {
+		m_bgImage = QImage();
+	}
+
+	updatePerspective();
+	resetCamera();
+
+	m_bgDirty = true;
+
+	update();
+}
+
+void WalkmeshRenderWidget::computeFov()
+{
+	if (m_fieldData && m_fieldData->hasCaFile()
+	    && camID < m_fieldData->getCaFile()->cameraCount()) {
+		const Camera &cam = m_fieldData->getCaFile()->camera(camID);
+		// FF8 camera_zoom to vertical FOV conversion:
+		// Using formula: fov = 2 * atan(screenHeight/(2*focalLength))
+		fovy = (2.0 * atan(240.0 / double(cam.camera_zoom) / 2.0))
+		       * (180.0 / M_PI);
+	} else {
+		fovy = 70.0;
+	}
+}
+
+void WalkmeshRenderWidget::setCurrentFieldCamera(int cam)
+{
+	camID = cam;
+	updatePerspective();
+}
+
+void WalkmeshRenderWidget::updatePerspective()
+{
+	computeFov();
+	if (rhi() && window()) {
+		// Recreate projection matrix on next render
+		resize(width(), height());
+	}
+	update();
+}
+
+void WalkmeshRenderWidget::keyPressEvent(QKeyEvent *event)
+{
+	const float step = 10.0f;
+	bool handled = true;
+	switch (event->key()) {
+	case Qt::Key_Left:
+		m_xTrans -= step;
+		break;
+	case Qt::Key_Right:
+		m_xTrans += step;
+		break;
+	case Qt::Key_Up:
+		m_yTrans += step;
+		break;
+	case Qt::Key_Down:
+		m_yTrans -= step;
+		break;
+	default:
+		handled = false;
+		break;
+	}
+	if (handled) {
+		update();
+	} else {
+		QRhiWidget::keyPressEvent(event);
+	}
+}
+
+// QRhi initialization: create pipelines and buffers
+void WalkmeshRenderWidget::initialize(QRhiCommandBuffer *cb)
+{
+	if (m_rhi != rhi()) {
+		m_rhi = rhi();
+		m_pipeline.reset();
+		m_bgPipeline.reset();
+		m_linePipeline.reset();
+		m_wireVbuf.reset();
+		m_exitsVbuf.reset();
+		m_doorsVbuf.reset();
+		m_bgVbuf.reset();
+		m_ubuf.reset();
+		m_srb.reset();
+		m_bgSrb.reset();
+		m_bgTexture.reset();
+		m_bgSampler.reset();
+		m_outerEdges.clear();
+		m_outerEdgesReady = false;
+	}
+	if (m_pipeline) { // already initialized
+		return;
+	}
+
+	// Uniform buffer (MVP)
+	m_ubuf.reset(
+	    m_rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 64));
+	m_ubuf->create();
+
+	// Dynamic vertex buffers (rebuilt every frame)
+	const int triCountInit = (m_fieldData && m_fieldData->hasIdFile())
+	                             ? m_fieldData->getIdFile()->triangleCount()
+	                             : 0;
+	const int wireVertsInit = qMax(1, triCountInit) * 6; // 3 edges * 2 verts
+
+	m_wireVbuf.reset(m_rhi->newBuffer(QRhiBuffer::Dynamic,
+	                                  QRhiBuffer::VertexBuffer,
+	                                  wireVertsInit * (6 * sizeof(float))));
+	m_wireVbuf->create();
+
+	// exits / doors / mesh (lines) get reasonable init, we grow if needed
+	m_exitsVbuf.reset(
+	    m_rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer,
+	                     1024 * 2 * 6 * sizeof(float))); // guess: 1024 lines
+	m_exitsVbuf->create();
+
+	m_doorsVbuf.reset(m_rhi->newBuffer(QRhiBuffer::Dynamic,
+	                                   QRhiBuffer::VertexBuffer,
+	                                   1024 * 2 * 6 * sizeof(float)));
+	m_doorsVbuf->create();
+
+	// SRB for MVP at binding 0 (vertex stage)
+	m_srb.reset(m_rhi->newShaderResourceBindings());
+	m_srb->setBindings({ QRhiShaderResourceBinding::uniformBuffer(
+	    0, QRhiShaderResourceBinding::VertexStage, m_ubuf.get()) });
+	m_srb->create();
+
+	// Triangles pipeline
+	m_pipeline.reset(m_rhi->newGraphicsPipeline());
+	m_pipeline->setDepthTest(true);
+	m_pipeline->setDepthWrite(true);
+	m_pipeline->setCullMode(QRhiGraphicsPipeline::None);
+	m_pipeline->setShaderStages(
+	    { { QRhiShaderStage::Vertex,
+	        loadShader(":/src/qt/shaders/walkmesh.vert.qsb") },
+	      { QRhiShaderStage::Fragment,
+	        loadShader(":/src/qt/shaders/walkmesh.frag.qsb") } });
+	{
+		QRhiVertexInputLayout layout;
+		layout.setBindings({ { 6 * sizeof(float) } });
+		layout.setAttributes(
+		    { { 0, 0, QRhiVertexInputAttribute::Float3, 0 },
+		      { 0, 1, QRhiVertexInputAttribute::Float3, 3 * sizeof(float) } });
+		m_pipeline->setVertexInputLayout(layout);
+	}
+	m_pipeline->setShaderResourceBindings(m_srb.get());
+	m_pipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
+	m_pipeline->setTopology(QRhiGraphicsPipeline::Triangles);
+	m_pipeline->create();
+
+	// Background quad VBO (x,y,u,v)
+	static const float bgQuadData[6 * 4] = { -1.0f, -1.0f, 0.0f,  1.0f,  1.0f,
+		                                     -1.0f, 1.0f,  1.0f,  1.0f,  1.0f,
+		                                     1.0f,  0.0f,  -1.0f, -1.0f, 0.0f,
+		                                     1.0f,  1.0f,  1.0f,  1.0f,  0.0f,
+		                                     -1.0f, 1.0f,  0.0f,  0.0f };
+	m_bgVbuf.reset(m_rhi->newBuffer(
+	    QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, sizeof(bgQuadData)));
+	m_bgVbuf->create();
+	{
+		QRhiResourceUpdateBatch *initBatch = m_rhi->nextResourceUpdateBatch();
+		initBatch->uploadStaticBuffer(m_bgVbuf.get(), bgQuadData);
+		cb->resourceUpdate(initBatch);
+	}
+
+	// Fallback BG sampler/texture/SRB (replaced when real image set)
+	if (!m_bgSampler) {
+		m_bgSampler.reset(m_rhi->newSampler(
+		    QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
+		    QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge));
+		m_bgSampler->create();
+	}
+	{
+		QImage dummy(1, 1, QImage::Format_RGBA8888);
+		dummy.fill(Qt::black);
+		m_bgTexture.reset(m_rhi->newTexture(QRhiTexture::RGBA8, dummy.size(), 1,
+		                                    QRhiTexture::UsedAsTransferSource));
+		m_bgTexture->create();
+		QRhiResourceUpdateBatch *rub = m_rhi->nextResourceUpdateBatch();
+		rub->uploadTexture(m_bgTexture.get(), dummy);
+		cb->resourceUpdate(rub);
+
+		m_bgSrb.reset(m_rhi->newShaderResourceBindings());
+		m_bgSrb->setBindings({ QRhiShaderResourceBinding::sampledTexture(
+		    1, QRhiShaderResourceBinding::FragmentStage, m_bgTexture.get(),
+		    m_bgSampler.get()) });
+		m_bgSrb->create();
+	}
+
+	// Background pipeline
+	m_bgPipeline.reset(m_rhi->newGraphicsPipeline());
+	m_bgPipeline->setDepthTest(false);
+	m_bgPipeline->setDepthWrite(false);
+	m_bgPipeline->setCullMode(QRhiGraphicsPipeline::None);
+	m_bgPipeline->setTopology(QRhiGraphicsPipeline::Triangles);
+	m_bgPipeline->setShaderStages(
+	    { { QRhiShaderStage::Vertex,
+	        loadShader(":/src/qt/shaders/background.vert.qsb") },
+	      { QRhiShaderStage::Fragment,
+	        loadShader(":/src/qt/shaders/background.frag.qsb") } });
+	{
+		QRhiVertexInputLayout bgLayout;
+		bgLayout.setBindings({ { 4 * sizeof(float) } });
+		bgLayout.setAttributes(
+		    { { 0, 0, QRhiVertexInputAttribute::Float2, 0 },
+		      { 0, 1, QRhiVertexInputAttribute::Float2, 2 * sizeof(float) } });
+		m_bgPipeline->setVertexInputLayout(bgLayout);
+	}
+	m_bgPipeline->setShaderResourceBindings(m_bgSrb.get());
+	m_bgPipeline->setRenderPassDescriptor(
+	    renderTarget()->renderPassDescriptor());
+	m_bgPipeline->create();
+
+	// Lines pipeline (wireframe + exits + doors + border)
+	m_linePipeline.reset(m_rhi->newGraphicsPipeline());
+	m_linePipeline->setDepthTest(false);
+	m_linePipeline->setDepthWrite(false);
+	m_linePipeline->setCullMode(QRhiGraphicsPipeline::None);
+	m_linePipeline->setTopology(QRhiGraphicsPipeline::Lines);
+	m_linePipeline->setShaderStages(
+	    { { QRhiShaderStage::Vertex,
+	        loadShader(":/src/qt/shaders/walkmesh.vert.qsb") },
+	      { QRhiShaderStage::Fragment,
+	        loadShader(":/src/qt/shaders/walkmesh.frag.qsb") } });
+	{
+		QRhiVertexInputLayout lyt;
+		lyt.setBindings({ { 6 * sizeof(float) } });
+		lyt.setAttributes(
+		    { { 0, 0, QRhiVertexInputAttribute::Float3, 0 },
+		      { 0, 1, QRhiVertexInputAttribute::Float3, 3 * sizeof(float) } });
+		m_linePipeline->setVertexInputLayout(lyt);
+	}
+	m_linePipeline->setShaderResourceBindings(m_srb.get());
+	m_linePipeline->setRenderPassDescriptor(
+	    renderTarget()->renderPassDescriptor());
+	m_linePipeline->create();
+}
+
+// Take a deep breath, and lets go
+void WalkmeshRenderWidget::render(QRhiCommandBuffer *cb)
+{
+	// Clear if no data
+	if (!m_fieldData) {
+		cb->beginPass(renderTarget(),
+		              m_backgroundVisible
+		                  ? Qt::black
+		                  : QColor::fromRgbF(0.2f, 0.2f, 0.2f, 1.0f),
+		              { 1.0f, 0 }, nullptr);
+		cb->endPass();
+		return;
+	}
+
+	// Ensure background SRB/texture is valid
+	if (m_bgDirty || !m_bgSrb || !m_bgTexture) {
+		rebuildBackgroundResources(cb);
+	}
+
+	const int triCount = m_fieldData->getIdFile()->triangleCount();
+
+	// STAGE 1: EDGE ACCUMULATION (dedupe) for WIREFRAME + BORDER + TRIANGLES
+	struct EdgeAccum {
+		Vertex a;
+		Vertex b;
+		int count = 0; // how many triangles reference this edge
+		bool highlight = false; // true if any owning triangle is selected
+	};
+
+	auto keyPoint = [](const Vertex &v) -> QString {
+		return QString::number(double(v.x), 'f', 6) + QLatin1Char(',')
+		       + QString::number(double(v.y), 'f', 6) + QLatin1Char(',')
+		       + QString::number(double(v.z), 'f', 6);
+	};
+	auto keyEdge = [&](const Vertex &p, const Vertex &q) -> QString {
+		const QString kp = keyPoint(p);
+		const QString kq = keyPoint(q);
+		return (kp < kq) ? (kp + QLatin1Char('|') + kq)
+		                 : (kq + QLatin1Char('|') + kp);
+	};
+
+	QHash<QString, EdgeAccum> edgeMap;
+	edgeMap.reserve(triCount * 3);
+
+	auto addEdge = [&](const Vertex &p, const Vertex &q, bool triSelected) {
+		const QString k = keyEdge(p, q);
+		auto it = edgeMap.find(k);
+		if (it == edgeMap.end()) {
+			EdgeAccum e;
+			e.a = p;
+			e.b = q;
+			e.count = 1;
+			e.highlight = triSelected;
+			edgeMap.insert(k, e);
+		} else {
+			it->count += 1;
+			if (triSelected)
+				it->highlight = true;
+		}
+	};
+
+	for (int ti = 0; ti < triCount; ++ti) {
+		const Triangle &tri = m_fieldData->getIdFile()->triangle(ti);
+		const bool selectedTri = (ti == _selectedTriangle);
+
+		const Vertex v0 = IdFile::toVertex_s(tri.vertices[0]);
+		const Vertex v1 = IdFile::toVertex_s(tri.vertices[1]);
+		const Vertex v2 = IdFile::toVertex_s(tri.vertices[2]);
+
+		addEdge(v0, v1, selectedTri);
+		addEdge(v1, v2, selectedTri);
+		addEdge(v2, v0, selectedTri);
+	}
+
+	// Compute once "outer edges at load", using this first valid edgeMap
+	if (!m_outerEdgesReady && !edgeMap.isEmpty()) {
+		m_outerEdges.clear();
+		for (auto it = edgeMap.constBegin(); it != edgeMap.constEnd(); ++it) {
+			if (it.value().count == 1) {
+				m_outerEdges.insert(it.key());
+			}
+		}
+		m_outerEdgesReady = true;
+	}
+
+	// STAGE 2: SINGLE-PASS BUILD of WIREFRAME with SEL_TRI > BORDER > MESH
+	struct LineV {
+		float x, y, z, r, g, b;
+	};
+	QVector<LineV> white;
+	white.reserve(edgeMap.size() * 2);
+	QVector<LineV> cyan;
+	cyan.reserve(edgeMap.size() / 2 * 2);
+	QVector<LineV> orange;
+	orange.reserve(6); // a few at most
+
+	auto pushEdge = [](QVector<LineV> &dst, const Vertex &a, const Vertex &b,
+	                   float r, float g, float bcol) {
+		// a
+		dst.push_back(LineV{ float(a.x), float(a.y), float(a.z), r, g, bcol });
+		// b
+		dst.push_back(LineV{ float(b.x), float(b.y), float(b.z), r, g, bcol });
+	};
+
+	for (auto it = edgeMap.constBegin(); it != edgeMap.constEnd(); ++it) {
+		const EdgeAccum &e = it.value();
+		const bool wasOuterAtLoad = m_outerEdges.contains(it.key());
+
+		if (e.highlight) {
+			// Selected triangle owns this edge -> ORANGE
+			pushEdge(orange, e.a, e.b, 1.0f, 0.5f, 0.0f);
+		} else if (wasOuterAtLoad) {
+			// Outer rim -> CYAN (frozen at load time)
+			pushEdge(cyan, e.a, e.b, 0.0f, 1.0f, 1.0f);
+		} else {
+			// Internal shared edge -> WHITE
+			pushEdge(white, e.a, e.b, 1.0f, 1.0f, 1.0f);
+		}
+	}
+
+	// Concatenate in priority order: WHITE first (lowest), CYAN, ORANGE
+	const int totalVerts = white.size() + cyan.size() + orange.size();
+	QByteArray wireData;
+	wireData.resize(totalVerts * int(sizeof(LineV)));
+	{
+		float *dst = reinterpret_cast<float *>(wireData.data());
+		auto dump = [&](const QVector<LineV> &v) {
+			const LineV *ptr = v.constData();
+			const int n = v.size() * int(sizeof(LineV)) / int(sizeof(float));
+			memcpy(dst, ptr, v.size() * sizeof(LineV));
+			dst += n;
+		};
+		dump(white);
+		dump(cyan);
+		dump(orange);
+	}
+	m_wireVertexCount = totalVerts;
+
+	// STAGE 3: SINGLE-PASS BUILD of EXITS and DOORS
+	QByteArray exitsData, doorsData;
+	m_exitsVertexCount = 0;
+	m_doorsVertexCount = 0;
+	if (m_fieldData->hasInfFile()) {
+		const auto *inf = m_fieldData->getInfFile();
+		// Exits (red)
+		// PS: Calling exits in UI and gateway here => fy :)
+		{
+			const int n = inf->gatewayCount();
+			exitsData.resize(n * 2 * 6 * int(sizeof(float)));
+			float *eptr = reinterpret_cast<float *>(exitsData.data());
+			for (int i = 0; i < n; ++i) {
+				const auto &gw = inf->getGateway(i);
+				// p0
+				*eptr++ = float(gw.exitLine[0].x);
+				*eptr++ = float(gw.exitLine[0].y);
+				*eptr++ = float(gw.exitLine[0].z);
+				*eptr++ = 1.0f;
+				*eptr++ = 0.0f;
+				*eptr++ = 0.0f;
+				// p1
+				*eptr++ = float(gw.exitLine[1].x);
+				*eptr++ = float(gw.exitLine[1].y);
+				*eptr++ = float(gw.exitLine[1].z);
+				*eptr++ = 1.0f;
+				*eptr++ = 0.0f;
+				*eptr++ = 0.0f;
+			}
+			m_exitsVertexCount = n * 2;
+		}
+		// Doors (green)
+		// PS: Calling doors in UI and trigger here => fy again :)
+		{
+			const int n = inf->triggerCount();
+			doorsData.resize(n * 2 * 6 * int(sizeof(float)));
+			float *dptr = reinterpret_cast<float *>(doorsData.data());
+			for (int i = 0; i < n; ++i) {
+				const auto &tr = inf->getTrigger(i);
+				// p0
+				*dptr++ = float(tr.trigger_line[0].x);
+				*dptr++ = float(tr.trigger_line[0].y);
+				*dptr++ = float(tr.trigger_line[0].z);
+				*dptr++ = 0.0f;
+				*dptr++ = 1.0f;
+				*dptr++ = 0.0f;
+				// p1
+				*dptr++ = float(tr.trigger_line[1].x);
+				*dptr++ = float(tr.trigger_line[1].y);
+				*dptr++ = float(tr.trigger_line[1].z);
+				*dptr++ = 0.0f;
+				*dptr++ = 1.0f;
+				*dptr++ = 0.0f;
+			}
+			m_doorsVertexCount = n * 2;
+		}
+	}
+
+	// STAGE 4: SINGLE-PASS BUILD of SELECTION SQUARES
+	QByteArray markersData;
+	{
+		QVector<QVector3D> pts;
+		QVector<QVector3D> cols;
+
+		// We always display the sel squares of triangle no matter the tab
+		if (_selectedTriangle >= 0 && _selectedTriangle < triCount) {
+			const Triangle &tri =
+			    m_fieldData->getIdFile()->triangle(_selectedTriangle);
+			const Vertex v0 = IdFile::toVertex_s(tri.vertices[0]);
+			const Vertex v1 = IdFile::toVertex_s(tri.vertices[1]);
+			const Vertex v2 = IdFile::toVertex_s(tri.vertices[2]);
+			const QVector3D col(1.0f, 0.5f, 0.0f);
+			pts << QVector3D(v0.x, v0.y, v0.z) << QVector3D(v1.x, v1.y, v1.z)
+			    << QVector3D(v2.x, v2.y, v2.z);
+			cols << col << col << col;
+		}
+		if (m_fieldData->hasInfFile()) {
+			const auto *inf = m_fieldData->getInfFile();
+			// Usage of isExitsTabSelected() make disp only in the exits tab
+			if (isExitsTabSelected() && _selectedGate >= 0
+			    && _selectedGate < inf->gatewayCount()) {
+				const auto &gw = inf->getGateway(_selectedGate);
+				const QVector3D col(1.0f, 0.0f, 0.0f);
+				pts << QVector3D(gw.exitLine[0].x, gw.exitLine[0].y,
+				                 gw.exitLine[0].z)
+				    << QVector3D(gw.exitLine[1].x, gw.exitLine[1].y,
+				                 gw.exitLine[1].z);
+				cols << col << col;
+			}
+			// Usage of isExitsTabSelected() make disp only in the doors tab
+			if (isDoorsTabSelected() && _selectedDoor >= 0
+			    && _selectedDoor < inf->triggerCount()) {
+				const auto &tr = inf->getTrigger(_selectedDoor);
+				const QVector3D col(0.0f, 1.0f, 0.0f);
+				pts << QVector3D(tr.trigger_line[0].x, tr.trigger_line[0].y,
+				                 tr.trigger_line[0].z)
+				    << QVector3D(tr.trigger_line[1].x, tr.trigger_line[1].y,
+				                 tr.trigger_line[1].z);
+				cols << col << col;
+			}
+		}
+
+		QVector3D right(1, 0, 0), up(0, 1, 0);
+		if (m_fieldData->hasCaFile()
+		    && camID < m_fieldData->getCaFile()->cameraCount()) {
+			const Camera &cam = m_fieldData->getCaFile()->camera(camID);
+			right = QVector3D(cam.camera_axis[0].x, cam.camera_axis[0].y,
+			                  cam.camera_axis[0].z);
+			up = QVector3D(cam.camera_axis[1].x, cam.camera_axis[1].y,
+			               cam.camera_axis[1].z);
+		}
+
+		auto sane = [](QVector3D v) -> QVector3D {
+			if (!qIsFinite(v.x()) || !qIsFinite(v.y()) || !qIsFinite(v.z()))
+				return QVector3D(0, 0, 0);
+			if (v.lengthSquared() < 1e-12f)
+				return QVector3D(0, 0, 0);
+			v.normalize();
+			return v;
+		};
+		right = sane(right);
+		if (right.isNull())
+			right = QVector3D(1, 0, 0);
+		up = sane(up);
+		if (up.isNull())
+			up = QVector3D(0, 1, 0);
+
+		const float s = 10.0f; // half-size of squares in world units
+		markersData.resize(pts.size()
+		                   * 6 /*verts*/ * 6 /*floats*/ * int(sizeof(float)));
+		float *mptr = reinterpret_cast<float *>(markersData.data());
+		auto putV = [&](const QVector3D &p, const QVector3D &c) {
+			*mptr++ = p.x();
+			*mptr++ = p.y();
+			*mptr++ = p.z();
+			*mptr++ = c.x();
+			*mptr++ = c.y();
+			*mptr++ = c.z();
+		};
+		for (int i = 0; i < pts.size(); ++i) {
+			const QVector3D c = pts[i];
+			const QVector3D col = cols[i];
+			const QVector3D a = c + (-s * right) + (-s * up);
+			const QVector3D b = c + (s * right) + (-s * up);
+			const QVector3D d = c + (s * right) + (s * up);
+			const QVector3D e = c + (-s * right) + (s * up);
+			putV(a, col);
+			putV(b, col);
+			putV(d, col);
+			putV(a, col);
+			putV(d, col);
+			putV(e, col);
+		}
+		m_markersVertexCount = pts.size() * 6;
+	}
+
+	// STAGE 5: UPLOAD the RESOURCES UPDATE (grow buffers if needed)
+	QRhiResourceUpdateBatch *rub = m_rhi->nextResourceUpdateBatch();
+	auto ensureUpdate = [&](std::unique_ptr<QRhiBuffer> &buf,
+	                        const QByteArray &data) {
+		if (!buf)
+			return;
+		const int needed = data.size();
+		if (needed > int(buf->size())) {
+			buf.reset(m_rhi->newBuffer(QRhiBuffer::Dynamic,
+			                           QRhiBuffer::VertexBuffer, needed));
+			buf->create();
+		}
+		if (needed > 0) {
+			rub->updateDynamicBuffer(buf.get(), 0, needed, data.constData());
+		}
+	};
+	ensureUpdate(m_wireVbuf, wireData);
+	ensureUpdate(m_exitsVbuf, exitsData);
+	ensureUpdate(m_doorsVbuf, doorsData);
+	if (!m_markersVbuf) {
+		m_markersVbuf.reset(m_rhi->newBuffer(
+		    QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer,
+		    qMax(6, m_markersVertexCount) * 6 * int(sizeof(float))));
+		m_markersVbuf->create();
+	}
+	ensureUpdate(m_markersVbuf, markersData);
+
+	// STAGE 6: MATRICES shared with SHADERS (Y‑flip + X‑flip)
+	const QSize outputSize = renderTarget()->pixelSize();
+
+	QMatrix4x4 proj;
+	proj = m_rhi->clipSpaceCorrMatrix();
+	proj.perspective(float(fovy),
+	                 outputSize.height()
+	                     ? (outputSize.width() / float(outputSize.height()))
+	                     : 1.0f,
+	                 1.0f, 10000.0f);
+
+	QMatrix4x4 view;
+	QVector3D right{ 1, 0, 0 };
+	QVector3D up{ 0, 0, 1 };
+	if (m_fieldData->hasCaFile()
+	    && camID < m_fieldData->getCaFile()->cameraCount()) {
+		const Camera &cam = m_fieldData->getCaFile()->camera(camID);
+		QVector3D eye(cam.camera_position[0], cam.camera_position[1],
+		              cam.camera_position[2]);
+		QVector3D rightAxis(cam.camera_axis[0].x, cam.camera_axis[0].y,
+		                    cam.camera_axis[0].z);
+		QVector3D upAxis(cam.camera_axis[1].x, cam.camera_axis[1].y,
+		                 cam.camera_axis[1].z);
+		QVector3D fwd(cam.camera_axis[2].x, cam.camera_axis[2].y,
+		              cam.camera_axis[2].z);
+		eye += m_xTrans * rightAxis + m_yTrans * upAxis;
+		QVector3D center = eye + fwd;
+		view.lookAt(eye, center, upAxis);
+	} else {
+		QVector3D eye(0.0f + m_xTrans, 0.0f + m_yTrans, 500.0f);
+		QVector3D center(m_xTrans, m_yTrans, 0.0f);
+		view.lookAt(eye, center, QVector3D(0, 1, 0));
+	}
+
+	QMatrix4x4 model;
+	model.setToIdentity();
+	model.scale(-1.0f, -1.0f, 1.0f); // X,Y flip
+	model.rotate(m_zRot, 0.0f, 0.0f, 1.0f);
+	model.rotate(m_yRot, 0.0f, 1.0f, 0.0f);
+	model.rotate(m_xRot, 1.0f, 0.0f, 0.0f);
+
+	const QMatrix4x4 mv = view * model;
+	bool okInv = false;
+	const QMatrix4x4 invMV = mv.inverted(&okInv);
+	if (okInv) {
+		right = invMV.column(0).toVector3D();
+		up = invMV.column(1).toVector3D();
+	}
+
+	const QMatrix4x4 mvp = proj * view * model;
+	rub->updateDynamicBuffer(m_ubuf.get(), 0, 64, mvp.constData());
+
+	// STAGE 7: COMMAND BUFFER START PASS + DRAWS
+	const QColor clearColor = m_backgroundVisible
+	                              ? Qt::black
+	                              : QColor::fromRgbF(0.2f, 0.2f, 0.2f, 1.0f);
+	cb->beginPass(renderTarget(), clearColor, { 1.0f, 0 }, rub);
+
+	// Background first (depth off in bg pipeline)
+	if (m_backgroundVisible && m_bgVbuf && m_bgPipeline && m_bgSrb
+	    && m_bgTexture) {
+		cb->setGraphicsPipeline(m_bgPipeline.get());
+		cb->setViewport(
+		    QRhiViewport(0, 0, outputSize.width(), outputSize.height()));
+		cb->setShaderResources(m_bgSrb.get());
+		const QRhiCommandBuffer::VertexInput bgBinding(m_bgVbuf.get(), 0);
+		cb->setVertexInput(0, 1, &bgBinding);
+		cb->draw(6);
+	}
+
+	// Lines
+	if (m_linePipeline && m_srb) {
+		cb->setGraphicsPipeline(m_linePipeline.get());
+		cb->setViewport(
+		    QRhiViewport(0, 0, outputSize.width(), outputSize.height()));
+		cb->setShaderResources(m_srb.get());
+
+		// Wiremesh
+		if (m_wireVbuf && m_wireVertexCount > 0) {
+			const QRhiCommandBuffer::VertexInput binding(m_wireVbuf.get(), 0);
+			cb->setVertexInput(0, 1, &binding);
+			cb->draw(m_wireVertexCount);
+		}
+		// Exits
+		if (m_exitsVbuf && m_exitsVertexCount > 0) {
+			const QRhiCommandBuffer::VertexInput binding(m_exitsVbuf.get(), 0);
+			cb->setVertexInput(0, 1, &binding);
+			cb->draw(m_exitsVertexCount);
+		}
+		// Doors
+		if (m_doorsVbuf && m_doorsVertexCount > 0) {
+			const QRhiCommandBuffer::VertexInput binding(m_doorsVbuf.get(), 0);
+			cb->setVertexInput(0, 1, &binding);
+			cb->draw(m_doorsVertexCount);
+		}
+	}
+
+	// Markers of selection (squares)
+	if (m_markersVbuf && m_pipeline && m_srb && m_markersVertexCount > 0) {
+		cb->setGraphicsPipeline(m_pipeline.get());
+		cb->setShaderResources(m_srb.get());
+		const QRhiCommandBuffer::VertexInput markersBinding(m_markersVbuf.get(),
+		                                                    0);
+		cb->setVertexInput(0, 1, &markersBinding);
+		cb->draw(m_markersVertexCount);
+	}
+
+	cb->endPass();
+	// We are done, return control :)
+}
+
+void WalkmeshRenderWidget::releaseResources()
+{
+	this->resetResources();
+}
+
+void WalkmeshRenderWidget::resetResources()
+{
+	m_pipeline.reset();
+	m_linePipeline.reset();
+	m_bgPipeline.reset();
+
+	m_srb.reset();
+	m_bgSrb.reset();
+
+	m_ubuf.reset();
+
+	m_wireVbuf.reset();
+	m_exitsVbuf.reset();
+	m_doorsVbuf.reset();
+	m_markersVbuf.reset();
+	m_bgVbuf.reset();
+
+	m_bgTexture.reset();
+	m_bgSampler.reset();
+
+	m_rhi = nullptr;
+}

--- a/src/widgets/WalkmeshRenderWidget.h
+++ b/src/widgets/WalkmeshRenderWidget.h
@@ -1,0 +1,108 @@
+/****************************************************************************
+ * * Deling QRhi port
+ ** Copyright (C) 2025 Alexandre 'kidev' Poumaroux <public@kidev.org>
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+#pragma once
+
+#include <QRhiWidget>
+#include <rhi/qrhi.h>
+#include <QImage>
+#include "Field.h"
+
+class WalkmeshRenderWidget : public QRhiWidget
+{
+	Q_OBJECT
+public:
+	WalkmeshRenderWidget(QWidget *parent = nullptr);
+	~WalkmeshRenderWidget() override;
+
+	void setXRotation(int angle);
+	void setYRotation(int angle);
+	void setZRotation(int angle);
+	void resetCamera();
+	void setBackgroundVisible(bool show);
+	void setCurrentTabIndex(int index);
+	void clear();
+
+	float xRot() const;
+	float yRot() const;
+	float zRot() const;
+
+	void setCurrentFieldCamera(int camID);
+	void updatePerspective();
+	void setSelectedTriangle(int triangle);
+	void setSelectedDoor(int door);
+	void setSelectedGate(int gate);
+	void setLineToDraw(const Vertex vertex[2]);
+	void computeFov();
+	void fill(Field *data);
+	void rebuildBackgroundResources(QRhiCommandBuffer *cb);
+
+protected:
+	void initialize(QRhiCommandBuffer *cb) override;
+	void render(QRhiCommandBuffer *cb) override;
+	void releaseResources() override;
+	void keyPressEvent(QKeyEvent *event) override;
+	void resetResources();
+
+private:
+	QRhi *m_rhi = nullptr;
+	std::unique_ptr<QRhiBuffer> m_ubuf;
+	std::unique_ptr<QRhiShaderResourceBindings> m_srb;
+	std::unique_ptr<QRhiGraphicsPipeline> m_pipeline;
+	std::unique_ptr<QRhiTexture> m_bgTexture;
+	std::unique_ptr<QRhiSampler> m_bgSampler;
+	std::unique_ptr<QRhiBuffer> m_bgVbuf;
+	std::unique_ptr<QRhiShaderResourceBindings> m_bgSrb;
+	std::unique_ptr<QRhiGraphicsPipeline> m_bgPipeline;
+	std::unique_ptr<QRhiGraphicsPipeline> m_linePipeline;
+	std::unique_ptr<QRhiBuffer> m_exitsVbuf;
+	std::unique_ptr<QRhiBuffer> m_markersVbuf;
+	std::unique_ptr<QRhiBuffer> m_doorsVbuf;
+	std::unique_ptr<QRhiBuffer> m_wireVbuf;
+	QSet<QString> m_outerEdges;
+
+	// Little helper functions as a treat
+	inline bool isExitsTabSelected() const
+	{
+		return _selectedTabIndex == 2;
+	}
+	inline bool isDoorsTabSelected() const
+	{
+		return _selectedTabIndex == 3;
+	}
+
+	// State
+	float m_xRot = 0.0f, m_yRot = 0.0f, m_zRot = 0.0f;
+	float m_xTrans = 0.0f, m_yTrans = 0.0f;
+	bool m_backgroundVisible = true;
+	Field *m_fieldData = nullptr;
+	QImage m_bgImage;
+	double fovy = 70.0;
+	Vertex _lineToDrawPoint1, _lineToDrawPoint2;
+	int camID = 0;
+	int _selectedTriangle = -1;
+	int _selectedDoor = -1;
+	int _selectedGate = -1;
+	int _selectedTabIndex = -1;
+	bool _drawLine = false;
+	int m_doorsVertexCount = 0;
+	int m_exitsVertexCount = 0;
+	int m_markersVertexCount = 0;
+	bool m_bgDirty = false;
+	bool m_outerEdgesReady = false;
+	int m_wireVertexCount = 0;
+};

--- a/src/widgets/WalkmeshWidget.h
+++ b/src/widgets/WalkmeshWidget.h
@@ -17,9 +17,13 @@
  ****************************************************************************/
 #pragma once
 
+#ifdef USE_OPENGL
+#include "gl/WalkmeshWidget.h"
+#else
+
 #include <QtWidgets>
+#include "widgets/WalkmeshRenderWidget.h"
 #include "widgets/PageWidget.h"
-#include "3d/WalkmeshGLWidget.h"
 #include "VertexWidget.h"
 #include "OrientationWidget.h"
 #include "HexLineEdit.h"
@@ -90,7 +94,7 @@ private:
 	void editRange2(int id, int v);
 	void editUnknownGate(int id, int val);
 
-	WalkmeshGLWidget *walkmeshGL;
+	WalkmeshRenderWidget *walkmeshRenderer;
 	QCheckBox *showBackground;
 	QSlider *slider1, *slider2, *slider3;
 	QTabWidget *tabWidget;
@@ -129,3 +133,5 @@ private:
 	HexLineEdit *unknown;
 	QSpinBox *cameraFocus;
 };
+
+#endif

--- a/src/widgets/WorldmapRenderWidget.cpp
+++ b/src/widgets/WorldmapRenderWidget.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
- ** Deling Final Fantasy VIII Field Editor
- ** Copyright (C) 2009-2024 Arzel Jérôme <myst6re@gmail.com>
+ * * Deling QRhi port
+ ** Copyright (C) 2025 Alexandre 'kidev' Poumaroux <public@kidev.org>
  **
  ** This program is free software: you can redistribute it and/or modify
  ** it under the terms of the GNU General Public License as published by
@@ -15,35 +15,4 @@
  ** You should have received a copy of the GNU General Public License
  ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
  ****************************************************************************/
-#pragma once
-
-#ifdef USE_OPENGL
-#include "gl/WorldmapWidget.h"
-#else
-
-#include <QtWidgets>
-#include "widgets/WorldmapRenderWidget.h"
-#include "widgets/PageWidget.h"
-
-class WorldmapWidget : public PageWidget
-{
-	Q_OBJECT
-public:
-	explicit WorldmapWidget(QWidget *parent = nullptr);
-	inline WorldmapRenderWidget *scene() const {
-		return _scene;
-	}
-	void fill() override;
-	inline QString tabName() const override { return tr("Worldmap"); }
-	void clear() override;
-private slots:
-	void setXRot(int value);
-	void setYRot(int value);
-	void setZRot(int value);
-	void resetCamera();
-private:
-	void build() override;
-	WorldmapRenderWidget *_scene;
-	QSlider *_xRotSlider, *_yRotSlider, *_zRotSlider;
-};
-#endif
+// WARNING: UNUSED IN PRACTICE, WORK IN PROGRESS, DO NOT OPEN MAPS

--- a/src/widgets/WorldmapRenderWidget.h
+++ b/src/widgets/WorldmapRenderWidget.h
@@ -1,6 +1,6 @@
 /****************************************************************************
- ** Deling Final Fantasy VIII Field Editor
- ** Copyright (C) 2009-2024 Arzel Jérôme <myst6re@gmail.com>
+ * * Deling QRhi port
+ ** Copyright (C) 2025 Alexandre 'kidev' Poumaroux <public@kidev.org>
  **
  ** This program is free software: you can redistribute it and/or modify
  ** it under the terms of the GNU General Public License as published by
@@ -15,35 +15,25 @@
  ** You should have received a copy of the GNU General Public License
  ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
  ****************************************************************************/
+// WARNING: UNUSED IN PRACTICE, WORK IN PROGRESS, DO NOT OPEN MAPS
+
 #pragma once
 
-#ifdef USE_OPENGL
-#include "gl/WorldmapWidget.h"
-#else
+#include "WalkmeshRenderWidget.h"
 
-#include <QtWidgets>
-#include "widgets/WorldmapRenderWidget.h"
-#include "widgets/PageWidget.h"
-
-class WorldmapWidget : public PageWidget
+class WorldmapRenderWidget : public WalkmeshRenderWidget
 {
 	Q_OBJECT
 public:
-	explicit WorldmapWidget(QWidget *parent = nullptr);
-	inline WorldmapRenderWidget *scene() const {
-		return _scene;
-	}
-	void fill() override;
-	inline QString tabName() const override { return tr("Worldmap"); }
-	void clear() override;
-private slots:
-	void setXRot(int value);
-	void setYRot(int value);
-	void setZRot(int value);
-	void resetCamera();
-private:
-	void build() override;
-	WorldmapRenderWidget *_scene;
-	QSlider *_xRotSlider, *_yRotSlider, *_zRotSlider;
+	WorldmapRenderWidget(QWidget *parent = nullptr) : WalkmeshRenderWidget(parent) {}
+	void setMap(Map* map) {Q_UNUSED(map);}
+	void setXTrans(float value) {Q_UNUSED(value);}
+	void setYTrans(float value) {Q_UNUSED(value);}
+	void setZTrans(float value) {Q_UNUSED(value);}
+	void setXRot(float value) {Q_UNUSED(value);}
+	void setYRot(float value) {Q_UNUSED(value);}
+	void setZRot(float value) {Q_UNUSED(value);}
+	float xRot() const {return 0.0f;}
+	float yRot() const {return 0.0f;}
+	float zRot() const {return 0.0f;}
 };
-#endif

--- a/src/widgets/gl/WalkmeshWidget.cpp
+++ b/src/widgets/gl/WalkmeshWidget.cpp
@@ -1,0 +1,1272 @@
+/****************************************************************************
+ ** Deling Final Fantasy VIII Field Editor
+ ** Copyright (C) 2009-2024 Arzel Jérôme <myst6re@gmail.com>
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+#include "widgets/WalkmeshWidget.h"
+#include "Data.h"
+#include "Config.h"
+#include "Listwidget.h"
+
+WalkmeshWidget::WalkmeshWidget(QWidget *parent) :
+	PageWidget(parent)
+{
+	walkmeshGL = new WalkmeshGLWidget(this);
+}
+
+void WalkmeshWidget::build()
+{
+	if (isBuilded())		return;
+
+	slider1 = new QSlider(this);
+	slider2 = new QSlider(this);
+	slider3 = new QSlider(this);
+
+	slider1->setRange(-180, 180);
+	slider2->setRange(-180, 180);
+	slider3->setRange(-180, 180);
+
+	slider1->setValue(0);
+	slider2->setValue(0);
+	slider3->setValue(0);
+
+	QLabel *keyInfos = new QLabel(tr("Use the arrow keys to move the camera."));
+	keyInfos->setTextFormat(Qt::PlainText);
+	keyInfos->setWordWrap(true);
+
+	QPushButton *resetCamera = new QPushButton(tr("Reset"));
+
+	showBackground = new QCheckBox(tr("Show background"));
+	showBackground->setChecked(Config::value("fieldBackgroundVisible", true).toBool());
+
+	tabWidget = new QTabWidget(this);
+	tabWidget->addTab(buildCameraPage(), tr("Camera"));
+	tabWidget->addTab(buildWalkmeshPage(), tr("Walkmesh"));
+	tabWidget->addTab(buildGatewaysPage(), tr("Exits"));
+	tabWidget->addTab(buildDoorsPage(), tr("Doors"));
+	tabWidget->addTab(buildCameraRangePage(), tr("Camera Ranges"));
+	tabWidget->addTab(buildMovieCameraPage(), tr("Movie Camera"));
+	tabWidget->addTab(buildMiscPage(), tr("Miscellaneous"));
+	tabWidget->setFixedHeight(250);
+
+	QGridLayout *layout = new QGridLayout(this);
+	layout->addWidget(walkmeshGL, 0, 0, 4, 1);
+	layout->addWidget(slider1, 0, 1, Qt::AlignLeft);
+	layout->addWidget(slider2, 0, 2, Qt::AlignHCenter);
+	layout->addWidget(slider3, 0, 3, Qt::AlignRight);
+	layout->addWidget(keyInfos, 1, 1, 1, 3);
+	layout->addWidget(resetCamera, 2, 1, 1, 3);
+	layout->addWidget(showBackground, 3, 1, 1, 3);
+	layout->addWidget(tabWidget, 4, 0, 1, 4);
+	layout->setColumnStretch(0, 1);
+	layout->setContentsMargins(QMargins());
+
+	connect(slider1, SIGNAL(valueChanged(int)), walkmeshGL, SLOT(setXRotation(int)));
+	connect(slider2, SIGNAL(valueChanged(int)), walkmeshGL, SLOT(setYRotation(int)));
+	connect(slider3, SIGNAL(valueChanged(int)), walkmeshGL, SLOT(setZRotation(int)));
+	connect(resetCamera, SIGNAL(clicked()), SLOT(resetCamera()));
+	connect(showBackground, SIGNAL(toggled(bool)), walkmeshGL, SLOT(setBackgroundVisible(bool)));
+
+	PageWidget::build();
+}
+
+void WalkmeshWidget::resetCamera()
+{
+	slider1->blockSignals(true);
+	slider2->blockSignals(true);
+	slider3->blockSignals(true);
+	slider1->setValue(0);
+	slider2->setValue(0);
+	slider3->setValue(0);
+	slider1->blockSignals(false);
+	slider2->blockSignals(false);
+	slider3->blockSignals(false);
+	walkmeshGL->resetCamera();
+}
+
+QWidget *WalkmeshWidget::buildCameraPage()
+{
+	QWidget *ret = new QWidget(this);
+
+	ListWidget *listWidget = new ListWidget(ret);
+	listWidget->addAction(ListWidget::Add, tr("Add camera"), this, SLOT(addCamera()));
+	listWidget->addAction(ListWidget::Rem, tr("Remove camera"), this, SLOT(removeCamera()));
+
+	caToolbar = listWidget->toolBar();
+	camList = listWidget->listWidget();
+
+	caVectorXEdit = new VertexWidget(ret);
+	caVectorYEdit = new VertexWidget(ret);
+	caVectorZEdit = new VertexWidget(ret);
+
+	caSpaceXEdit = new QDoubleSpinBox(ret);
+	qreal maxInt = qPow(2,31);
+	caSpaceXEdit->setRange(-maxInt, maxInt);
+	caSpaceXEdit->setDecimals(0);
+	caSpaceYEdit = new QDoubleSpinBox(ret);
+	caSpaceYEdit->setRange(-maxInt, maxInt);
+	caSpaceYEdit->setDecimals(0);
+	caSpaceZEdit = new QDoubleSpinBox(ret);
+	caSpaceZEdit->setRange(-maxInt, maxInt);
+	caSpaceZEdit->setDecimals(0);
+
+	caZoomEdit = new QSpinBox(ret);
+	caZoomEdit->setRange(-32768, 32767);
+
+	QGridLayout *caLayout = new QGridLayout(ret);
+	caLayout->addWidget(listWidget, 0, 0, 8, 1);
+	caLayout->addWidget(new QLabel(tr("Zoom:")), 0, 1, 1, 3);
+	caLayout->addWidget(caZoomEdit, 0, 4, 1, 2);
+	caLayout->addWidget(new QLabel(tr("Camera axis:")), 1, 1, 1, 6);
+	caLayout->addWidget(caVectorXEdit, 2, 1, 1, 6);
+	caLayout->addWidget(caVectorYEdit, 3, 1, 1, 6);
+	caLayout->addWidget(caVectorZEdit, 4, 1, 1, 6);
+	caLayout->addWidget(new QLabel(tr("Camera position:")), 5, 1, 1, 6);
+	caLayout->addWidget(new QLabel(tr("X")), 6, 1);
+	caLayout->addWidget(caSpaceXEdit, 6, 2);
+	caLayout->addWidget(new QLabel(tr("Y")), 6, 3);
+	caLayout->addWidget(caSpaceYEdit, 6, 4);
+	caLayout->addWidget(new QLabel(tr("Z")), 6, 5);
+	caLayout->addWidget(caSpaceZEdit, 6, 6);
+	caLayout->setRowStretch(7, 1);
+	caLayout->setColumnStretch(2, 1);
+	caLayout->setColumnStretch(4, 1);
+	caLayout->setColumnStretch(6, 1);
+
+	connect(camList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentCamera(int)));
+
+	connect(caVectorXEdit, SIGNAL(valuesChanged(Vertex)), SLOT(editCaVector(Vertex)));
+	connect(caVectorYEdit, SIGNAL(valuesChanged(Vertex)), SLOT(editCaVector(Vertex)));
+	connect(caVectorZEdit, SIGNAL(valuesChanged(Vertex)), SLOT(editCaVector(Vertex)));
+
+	connect(caSpaceXEdit, SIGNAL(valueChanged(double)), SLOT(editCaPos(double)));
+	connect(caSpaceYEdit, SIGNAL(valueChanged(double)), SLOT(editCaPos(double)));
+	connect(caSpaceZEdit, SIGNAL(valueChanged(double)), SLOT(editCaPos(double)));
+
+	connect(caZoomEdit, SIGNAL(valueChanged(int)), SLOT(editCaZoom(int)));
+
+	return ret;
+}
+
+QWidget *WalkmeshWidget::buildWalkmeshPage()
+{
+	QWidget *ret = new QWidget(this);
+
+	ListWidget *listWidget = new ListWidget(ret);
+	listWidget->addAction(ListWidget::Add, tr("Add triangle"), this, SLOT(addTriangle()));
+	listWidget->addAction(ListWidget::Rem, tr("Remove triangle"), this, SLOT(removeTriangle()));
+
+	idToolbar = listWidget->toolBar();
+	idList = listWidget->listWidget();
+
+	idVertices[0] = new VertexWidget(ret);
+	idVertices[1] = new VertexWidget(ret);
+	idVertices[2] = new VertexWidget(ret);
+
+	idAccess[0] = new QSpinBox(ret);
+	idAccess[1] = new QSpinBox(ret);
+	idAccess[2] = new QSpinBox(ret);
+
+	idAccess[0]->setRange(-32768, 32767);
+	idAccess[1]->setRange(-32768, 32767);
+	idAccess[2]->setRange(-32768, 32767);
+
+	QHBoxLayout *accessLayout0 = new QHBoxLayout;
+	accessLayout0->addWidget(new QLabel(tr("Triangle accessible via the line 1-2:")));
+	accessLayout0->addWidget(idAccess[0]);
+
+	QHBoxLayout *accessLayout1 = new QHBoxLayout;
+	accessLayout1->addWidget(new QLabel(tr("Triangle accessible via la ligne 2-3:")));
+	accessLayout1->addWidget(idAccess[1]);
+
+	QHBoxLayout *accessLayout2 = new QHBoxLayout;
+	accessLayout2->addWidget(new QLabel(tr("Triangle accessible via la ligne 3-1:")));
+	accessLayout2->addWidget(idAccess[2]);
+
+	QGridLayout *layout = new QGridLayout(ret);
+	layout->addWidget(listWidget, 0, 0, 7, 1, Qt::AlignLeft);
+	layout->addWidget(new QLabel(tr("Point 1:")), 0, 1);
+	layout->addWidget(idVertices[0], 0, 2);
+	layout->addWidget(new QLabel(tr("Point 2:")), 1, 1);
+	layout->addWidget(idVertices[1], 1, 2);
+	layout->addWidget(new QLabel(tr("Point 3:")), 2, 1);
+	layout->addWidget(idVertices[2], 2, 2);
+	layout->addLayout(accessLayout0, 3, 1, 1, 2);
+	layout->addLayout(accessLayout1, 4, 1, 1, 2);
+	layout->addLayout(accessLayout2, 5, 1, 1, 2);
+	layout->setRowStretch(6, 1);
+
+	connect(idList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentId(int)));
+	connect(idVertices[0], SIGNAL(valuesChanged(Vertex)), SLOT(editIdTriangle(Vertex)));
+	connect(idVertices[1], SIGNAL(valuesChanged(Vertex)), SLOT(editIdTriangle(Vertex)));
+	connect(idVertices[2], SIGNAL(valuesChanged(Vertex)), SLOT(editIdTriangle(Vertex)));
+	connect(idAccess[0], SIGNAL(valueChanged(int)), SLOT(editIdAccess(int)));
+	connect(idAccess[1], SIGNAL(valueChanged(int)), SLOT(editIdAccess(int)));
+	connect(idAccess[2], SIGNAL(valueChanged(int)), SLOT(editIdAccess(int)));
+
+	return ret;
+}
+
+QWidget *WalkmeshWidget::buildGatewaysPage()
+{
+	QWidget *ret = new QWidget(this);
+
+	gateList = new QListWidget(ret);
+	gateList->setFixedWidth(125);
+
+	exitPoints[0] = new VertexWidget(ret);
+	exitPoints[1] = new VertexWidget(ret);
+	entryPoint = new VertexWidget(ret);
+
+	fieldId = new QSpinBox(ret);
+	fieldId->setRange(0, 65535);
+
+	for (int i = 0; i < 4; ++i) {
+		unknownGate1[i] = new QSpinBox(ret);
+		unknownGate1[i]->setRange(0, 65535);
+	}
+	unknownGate2 = new HexLineEdit(ret);
+
+	QGridLayout *idsLayout = new QGridLayout;
+	idsLayout->addWidget(new QLabel(tr("Field ID:")), 0, 0);
+	idsLayout->addWidget(fieldId, 0, 1, 1, 4);
+	idsLayout->addWidget(new QLabel(tr("Unknown 1:")), 1, 0);
+	idsLayout->addWidget(unknownGate1[0], 1, 1);
+	idsLayout->addWidget(unknownGate1[1], 1, 2);
+	idsLayout->addWidget(unknownGate1[2], 1, 3);
+	idsLayout->addWidget(unknownGate1[3], 1, 4);
+	idsLayout->addWidget(new QLabel(tr("Unknown 2:")), 2, 0);
+	idsLayout->addWidget(unknownGate2, 2, 1, 1, 4);
+
+	QGridLayout *layout = new QGridLayout(ret);
+	layout->addWidget(gateList, 0, 0, 5, 1, Qt::AlignLeft);
+	layout->addWidget(new QLabel(tr("Exit Line:")), 0, 1);
+	layout->addWidget(exitPoints[0], 0, 2);
+	layout->addWidget(exitPoints[1], 1, 2);
+	layout->addWidget(new QLabel(tr("Destination point:")), 2, 1);
+	layout->addWidget(entryPoint, 2, 2);
+	layout->addLayout(idsLayout, 3, 1, 1, 2);
+	layout->setRowStretch(4, 1);
+
+	connect(gateList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentGateway(int)));
+	connect(exitPoints[0], SIGNAL(valuesChanged(Vertex)), SLOT(editExitPoint(Vertex)));
+	connect(exitPoints[1], SIGNAL(valuesChanged(Vertex)), SLOT(editExitPoint(Vertex)));
+	connect(entryPoint, SIGNAL(valuesChanged(Vertex)), SLOT(editEntryPoint(Vertex)));
+	connect(fieldId, SIGNAL(valueChanged(int)), SLOT(editFieldId(int)));
+	for (int i = 0; i < 4; ++i) {
+		connect(unknownGate1[i], SIGNAL(valueChanged(int)), SLOT(editUnknownGate(int)));
+	}
+	connect(unknownGate2, SIGNAL(dataEdited(QByteArray)), SLOT(editUnknownGate(QByteArray)));
+
+	return ret;
+}
+
+QWidget *WalkmeshWidget::buildDoorsPage()
+{
+	QWidget *ret = new QWidget(this);
+
+	doorList = new QListWidget(ret);
+	doorList->setFixedWidth(125);
+
+	doorPosition[0] = new VertexWidget(ret);
+	doorPosition[1] = new VertexWidget(ret);
+
+	doorUsed = new QCheckBox(tr("Used"));
+
+	doorId = new QSpinBox(ret);
+	doorId->setRange(0, 254);
+
+	QGridLayout *idsLayout = new QGridLayout;
+	idsLayout->addWidget(doorUsed, 0, 0);
+	idsLayout->addWidget(new QLabel(tr("Door ID:")), 0, 1);
+	idsLayout->addWidget(doorId, 0, 2);
+
+	QGridLayout *layout = new QGridLayout(ret);
+	layout->addWidget(doorList, 0, 0, 4, 1, Qt::AlignLeft);
+	layout->addWidget(new QLabel(tr("Trigger Line Door:")), 0, 1);
+	layout->addWidget(doorPosition[0], 0, 2);
+	layout->addWidget(doorPosition[1], 1, 2);
+	layout->addLayout(idsLayout, 2, 1, 1, 2);
+	layout->setRowStretch(3, 1);
+
+	connect(doorList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentDoor(int)));
+	connect(doorPosition[0], SIGNAL(valuesChanged(Vertex)), SLOT(editDoorPoint(Vertex)));
+	connect(doorPosition[1], SIGNAL(valuesChanged(Vertex)), SLOT(editDoorPoint(Vertex)));
+	connect(doorUsed, SIGNAL(toggled(bool)), SLOT(editDoorUsed(bool)));
+	connect(doorId, SIGNAL(valueChanged(int)), SLOT(editDoorId(int)));
+
+	return ret;
+}
+
+QWidget *WalkmeshWidget::buildCameraRangePage()
+{
+	QWidget *ret = new QWidget(this);
+
+	rangeList1 = new QListWidget(ret);
+
+	for (int i = 0; i < 8; ++i) {
+		rangeList1->addItem(tr("Camera Range %1").arg(i+1));
+	}
+
+	rangeList2 = new QListWidget(ret);
+
+	for (int i = 0; i < 2; ++i) {
+		rangeList2->addItem(tr("Screen Range %1").arg(i+1));
+	}
+
+	for (int i = 0; i < 4; ++i) {
+		rangeEdit1[i] = new QSpinBox(ret);
+		rangeEdit1[i]->setRange(-32768, 32767);
+		rangeEdit2[i] = new QSpinBox(ret);
+		rangeEdit2[i]->setRange(-32768, 32767);
+	}
+
+	QGridLayout *layout = new QGridLayout(ret);
+	layout->addWidget(rangeList1, 0, 0, 3, 1, Qt::AlignLeft);
+	layout->addWidget(rangeList2, 3, 0, 3, 1, Qt::AlignLeft);
+	layout->addWidget(new QLabel(tr("Top")), 0, 1);
+	layout->addWidget(rangeEdit1[0], 0, 2);
+	layout->addWidget(new QLabel(tr("Bottom")), 0, 3);
+	layout->addWidget(rangeEdit1[1], 0, 4);
+	layout->addWidget(new QLabel(tr("Right")), 1, 1);
+	layout->addWidget(rangeEdit1[2], 1, 2);
+	layout->addWidget(new QLabel(tr("Left")), 1, 3);
+	layout->addWidget(rangeEdit1[3], 1, 4);
+	layout->addWidget(new QLabel(tr("Top")), 3, 1);
+	layout->addWidget(rangeEdit2[0], 3, 2);
+	layout->addWidget(new QLabel(tr("Bottom")), 3, 3);
+	layout->addWidget(rangeEdit2[1], 3, 4);
+	layout->addWidget(new QLabel(tr("Right")), 4, 1);
+	layout->addWidget(rangeEdit2[2], 4, 2);
+	layout->addWidget(new QLabel(tr("Left")), 4, 3);
+	layout->addWidget(rangeEdit2[3], 4, 4);
+	layout->setRowStretch(2, 1);
+	layout->setRowStretch(5, 1);
+	layout->setColumnStretch(1, 1);
+	layout->setColumnStretch(2, 1);
+	layout->setColumnStretch(3, 1);
+	layout->setColumnStretch(4, 1);
+
+	connect(rangeList1, SIGNAL(currentRowChanged(int)), SLOT(setCurrentRange1(int)));
+	connect(rangeList2, SIGNAL(currentRowChanged(int)), SLOT(setCurrentRange2(int)));
+	for (int i = 0; i < 4; ++i) {
+		connect(rangeEdit1[i], SIGNAL(valueChanged(int)), SLOT(editRange(int)));
+		connect(rangeEdit2[i], SIGNAL(valueChanged(int)), SLOT(editRange(int)));
+	}
+
+	return ret;
+}
+
+QWidget *WalkmeshWidget::buildMovieCameraPage()
+{
+	QWidget *ret = new QWidget(this);
+
+	ListWidget *listWidget = new ListWidget(ret);
+	camPlusAction = listWidget->addAction(ListWidget::Add, tr("Add"), this, SLOT(addMovieCameraPosition()));
+	camMinusAction = listWidget->addAction(ListWidget::Rem, tr("Remove"), this, SLOT(removeMovieCameraPosition()));
+	camToolbar = listWidget->toolBar();
+
+	frameList = listWidget->listWidget();
+	//	frameList->setDragDropMode(QAbstractItemView::InternalMove);//TODO
+
+	camPoints[0] = new VertexWidget(ret);
+	camPoints[1] = new VertexWidget(ret);
+	camPoints[2] = new VertexWidget(ret);
+	camPoints[3] = new VertexWidget(ret);
+
+	QGridLayout *layout = new QGridLayout(ret);
+	layout->addWidget(listWidget, 0, 0, 5, 1);
+	layout->addWidget(camPoints[0], 0, 1);
+	layout->addWidget(camPoints[1], 1, 1);
+	layout->addWidget(camPoints[2], 2, 1);
+	layout->addWidget(camPoints[3], 3, 1);
+	layout->setRowStretch(4, 1);
+	layout->setColumnStretch(1, 1);
+
+	connect(frameList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentMoviePosition(int)));
+
+	return ret;
+}
+
+QWidget *WalkmeshWidget::buildMiscPage()
+{
+	QWidget *ret = new QWidget(this);
+
+	navigation = new OrientationWidget(ret);
+	navigation2 = new QSpinBox(ret);
+	navigation2->setRange(0, 255);
+	navigation2->setWrapping(true);
+
+	unknown = new HexLineEdit(ret);
+	cameraFocus = new QSpinBox(ret);
+	cameraFocus->setRange(-32768, 32767);
+
+	QGridLayout *layout = new QGridLayout(ret);
+	layout->addWidget(new QLabel(tr("Movements orientation:")), 0, 0);
+	layout->addWidget(navigation, 0, 1);
+	layout->addWidget(navigation2, 0, 2);
+	layout->addWidget(new QLabel(tr("Unknown:")), 1, 0);
+	layout->addWidget(unknown, 1, 1, 1, 2);
+	layout->addWidget(new QLabel(tr("Camera Focus Height on the playable character:")), 2, 0);
+	layout->addWidget(cameraFocus, 2, 1, 1, 2);
+	layout->setRowStretch(4, 1);
+
+	connect(navigation, SIGNAL(valueEdited(int)), navigation2, SLOT(setValue(int)));
+	connect(navigation2, SIGNAL(valueChanged(int)), SLOT(editNavigation(int)));
+	connect(unknown, SIGNAL(dataEdited(QByteArray)), SLOT(editUnknown(QByteArray)));
+	connect(cameraFocus, SIGNAL(valueChanged(int)), SLOT(editCameraFocus(int)));
+
+	return ret;
+}
+
+void WalkmeshWidget::clear()
+{
+	if (!isFilled())		return;
+
+	walkmeshGL->clear();
+
+	blockSignals(true);
+	camList->clear();
+	idList->clear();
+	gateList->clear();
+	doorList->clear();
+	frameList->clear();
+	blockSignals(false);
+
+	PageWidget::clear();
+}
+
+void WalkmeshWidget::setReadOnly(bool ro)
+{
+	if (isBuilded()) {
+		// CamPage
+		caToolbar->setDisabled(ro);
+		caVectorXEdit->setReadOnly(ro);
+		caVectorYEdit->setReadOnly(ro);
+		caVectorZEdit->setReadOnly(ro);
+		caSpaceXEdit->setReadOnly(ro);
+		caSpaceYEdit->setReadOnly(ro);
+		caSpaceZEdit->setReadOnly(ro);
+		caZoomEdit->setReadOnly(ro);
+		// WalkPage
+		idToolbar->setDisabled(ro);
+		for (int i = 0; i < 3; ++i) {
+			idVertices[i]->setReadOnly(ro);
+			idAccess[i]->setReadOnly(ro);
+		}
+		// GatePage
+		exitPoints[0]->setReadOnly(ro);
+		exitPoints[1]->setReadOnly(ro);
+		entryPoint->setReadOnly(ro);
+		fieldId->setReadOnly(ro);
+		for (int i=0 ; i<4 ; ++i) 	unknownGate1[i]->setReadOnly(ro);
+		unknownGate2->setReadOnly(ro);
+		// DoorPage
+		doorId->setReadOnly(ro);
+		doorPosition[0]->setReadOnly(ro);
+		doorPosition[1]->setReadOnly(ro);
+		doorUsed->setDisabled(ro);
+		// CamRangePage
+		for (int i = 0; i < 4; ++i) {
+			rangeEdit1[i]->setReadOnly(ro);
+			rangeEdit2[i]->setReadOnly(ro);
+		}
+		// MoveCamPage
+		camToolbar->setDisabled(ro);
+		for (int i=0 ; i<4 ; ++i)	camPoints[i]->setReadOnly(ro);
+		// MiscPage
+		navigation->setReadOnly(ro);
+		navigation2->setReadOnly(ro);
+		unknown->setReadOnly(ro);
+		cameraFocus->setReadOnly(ro);
+	}
+
+	PageWidget::setReadOnly(ro);
+}
+
+void WalkmeshWidget::fill()
+{
+	if (!isBuilded())	build();
+	if (isFilled())		clear();
+
+	if (!hasData() ||
+			(!data()->hasCaFile()
+			 && !data()->hasIdFile()
+			 && !data()->hasInfFile())) return;
+
+	walkmeshGL->fill(data());
+
+	int camCount = 0;
+
+	if (data()->hasCaFile()) {
+		camCount = data()->getCaFile()->cameraCount();
+
+		if (camList->count() != camCount) {
+			camList->blockSignals(true);
+			camList->clear();
+			for (int i = 0; i < camCount; ++i) {
+				camList->addItem(tr("Camera %1").arg(i));
+			}
+			camList->blockSignals(false);
+		}
+
+		setCurrentCamera(0);
+	}
+	tabWidget->widget(0)->setEnabled(data()->hasCaFile() && camCount > 0);
+
+	if (data()->hasIdFile()) {
+		int triangleCount = data()->getIdFile()->triangleCount();
+
+		if (idList->count() != triangleCount) {
+			idList->blockSignals(true);
+			idList->clear();
+			for (int i = 0; i < triangleCount; ++i) {
+				idList->addItem(tr("Triangle %1").arg(i));
+			}
+			idList->blockSignals(false);
+		}
+		idList->setCurrentRow(0);
+		setCurrentId(0);
+	}
+	tabWidget->widget(1)->setEnabled(data()->hasIdFile());
+
+	if (data()->hasInfFile()) {
+		gateList->clear();
+		for (const Gateway &gateway: data()->getInfFile()->getGateways()) {
+			if (gateway.fieldId != 0x7FFF) {
+				gateList->addItem(QString("%1 (%2)").arg(Data::maplist().value(gateway.fieldId)).arg(gateway.fieldId));
+			} else {
+				gateList->addItem(tr("Unused"));
+			}
+		}
+		gateList->setCurrentRow(0);
+		setCurrentGateway(0);
+
+		doorList->clear();
+		for (const Trigger &trigger: data()->getInfFile()->getTriggers(false)) {
+			if (trigger.doorID != 0xFF) {
+				doorList->addItem(tr("Door %1").arg(trigger.doorID));
+			} else {
+				doorList->addItem(tr("Unused"));
+			}
+		}
+		doorList->setCurrentRow(0);
+		setCurrentDoor(0);
+
+		rangeList1->setCurrentRow(0);
+		setCurrentRange1(0);
+		rangeList2->setCurrentRow(0);
+		setCurrentRange2(0);
+
+		navigation->setValue(data()->getInfFile()->controlDirection());
+		navigation2->setValue(data()->getInfFile()->controlDirection());
+		unknown->setData(data()->getInfFile()->unknown());
+		cameraFocus->setValue(data()->getInfFile()->cameraFocusHeight());
+	}
+	tabWidget->widget(2)->setEnabled(data()->hasInfFile());
+	tabWidget->widget(3)->setEnabled(data()->hasInfFile());
+	tabWidget->widget(4)->setEnabled(data()->hasInfFile());
+	tabWidget->widget(6)->setEnabled(data()->hasInfFile());
+
+	if (data()->hasMskFile()) {
+		frameList->clear();
+		int cameraPositionCount = data()->getMskFile()->cameraPositionCount();
+		for (int i = 0; i < cameraPositionCount; ++i) {
+			frameList->addItem(tr("Position %1").arg(i+1));
+		}
+		frameList->setCurrentRow(0);
+		setCurrentMoviePosition(0);
+	}
+//	tabWidget->widget(5)->setEnabled(data()->hasMskFile());
+
+	PageWidget::fill();
+}
+
+int WalkmeshWidget::currentCamera() const
+{
+	if (!data()->hasCaFile())	return 0;
+
+	int camID = camList->currentRow();
+	return camID < 0 || camID >= data()->getCaFile()->cameraCount() ? 0 : camID;
+}
+
+void WalkmeshWidget::setCurrentCamera(int camID)
+{
+	if (!data()->hasCaFile() || camID < 0) {
+		return;
+	}
+
+	bool hasCamera = camID < data()->getCaFile()->cameraCount();
+
+	if (hasCamera) {
+		const Camera &cam = data()->getCaFile()->camera(camID);
+
+		//		qDebug() << cam.camera_axis[0].x << cam.camera_axis[0].y << cam.camera_axis[0].z;
+		//		qDebug() << cam.camera_axis[1].x << cam.camera_axis[1].y << cam.camera_axis[1].z;
+		//		qDebug() << cam.camera_axis[2].x << cam.camera_axis[2].y << cam.camera_axis[2].z;
+		//		qDebug() << cam.camera_position[0] << cam.camera_position[1] << cam.camera_position[2];
+
+		blockSignals(true);
+		caVectorXEdit->setValues(cam.camera_axis[0]);
+		caVectorYEdit->setValues(cam.camera_axis[1]);
+		caVectorZEdit->setValues(cam.camera_axis[2]);
+
+		caSpaceXEdit->setValue(cam.camera_position[0]);
+		caSpaceYEdit->setValue(cam.camera_position[1]);
+		caSpaceZEdit->setValue(cam.camera_position[2]);
+
+		caZoomEdit->setValue(cam.camera_zoom);
+
+		walkmeshGL->setCurrentFieldCamera(camID);
+		blockSignals(false);
+	}
+
+	caVectorXEdit->setEnabled(hasCamera);
+	caVectorYEdit->setEnabled(hasCamera);
+	caVectorZEdit->setEnabled(hasCamera);
+
+	caSpaceXEdit->setEnabled(hasCamera);
+	caSpaceYEdit->setEnabled(hasCamera);
+	caSpaceZEdit->setEnabled(hasCamera);
+
+	caZoomEdit->setEnabled(hasCamera);
+
+	if (camList->currentRow() != camID) {
+		camList->blockSignals(true);
+		camList->setCurrentRow(camID);
+		camList->blockSignals(false);
+	}
+}
+
+void WalkmeshWidget::addCamera()
+{
+	int row = camList->currentRow();
+
+	if (data()->hasCaFile()) {
+		Camera ca;
+		if (row < data()->getCaFile()->cameraCount()) {
+			ca = data()->getCaFile()->camera(row);
+		} else {
+			ca = Camera();
+		}
+		data()->getCaFile()->insertCamera(row+1, ca);
+		camList->insertItem(row+1, tr("Camera %1").arg(row+1));
+		for (int i = row + 2; i < camList->count(); ++i) {
+			camList->item(i)->setText(tr("Camera %1").arg(i));
+		}
+		camList->setCurrentRow(row+1);
+		emit modified();
+	}
+}
+
+void WalkmeshWidget::removeCamera()
+{
+	if (data()->getCaFile()->cameraCount() < 2) return;
+
+	int row = camList->currentRow();
+
+	if (row < 0)		return;
+
+	if (data()->hasCaFile() && row < data()->getCaFile()->cameraCount()) {
+		data()->getCaFile()->removeCamera(row);
+		delete camList->item(row);
+		for (int i = row; i < camList->count(); ++i) {
+			camList->item(i)->setText(tr("Camera %1").arg(i));
+		}
+		setCurrentCamera(row);
+		emit modified();
+	}
+}
+
+void WalkmeshWidget::editCaVector(const Vertex &values)
+{
+	QObject *s = sender();
+
+	if (s == caVectorXEdit)			editCaVector(0, values);
+	else if (s == caVectorYEdit)		editCaVector(1, values);
+	else if (s == caVectorZEdit)		editCaVector(2, values);
+}
+
+void WalkmeshWidget::editCaVector(int id, const Vertex &values)
+{
+	if (data()->hasCaFile() && data()->getCaFile()->cameraCount() > 0) {
+		const int camID = currentCamera();
+		Camera cam = data()->getCaFile()->camera(camID);
+		Vertex oldV = cam.camera_axis[id];
+
+		if (oldV.x != values.x || oldV.y != values.y || oldV.z != values.z) {
+			cam.camera_axis[id] = values;
+			data()->getCaFile()->setCamera(camID, cam);
+			walkmeshGL->update();
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editCaPos(double value)
+{
+	QObject *s = sender();
+
+	if (s == caSpaceXEdit)			editCaPos(0, value);
+	else if (s == caSpaceYEdit)		editCaPos(1, value);
+	else if (s == caSpaceZEdit)		editCaPos(2, value);
+}
+
+void WalkmeshWidget::editCaPos(int id, double value)
+{
+	if (data()->hasCaFile() && data()->getCaFile()->cameraCount() > 0) {
+		const int camID = currentCamera();
+		Camera cam = data()->getCaFile()->camera(camID);
+		if (cam.camera_position[id] != (qint32)value) {
+			cam.camera_position[id] = value;
+			data()->getCaFile()->setCamera(camID, cam);
+			walkmeshGL->update();
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editCaZoom(int value)
+{
+	if (data()->hasCaFile() && data()->getCaFile()->cameraCount() > 0) {
+		const int camID = currentCamera();
+		Camera cam = data()->getCaFile()->camera(camID);
+		if (cam.camera_zoom != value) {
+			cam.camera_zoom = value;
+			data()->getCaFile()->setCamera(camID, cam);
+			walkmeshGL->updatePerspective();
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::setCurrentId(int i)
+{
+	if (!data()->hasIdFile() || i < 0)	return;
+
+	IdFile *id = data()->getIdFile();
+	if (id->triangleCount() <= i)	return;
+
+	const Triangle &triangle = id->triangle(i);
+	const Access &access = id->access(i);
+
+	idVertices[0]->setValues(IdFile::toVertex_s(triangle.vertices[0]));
+	idVertices[1]->setValues(IdFile::toVertex_s(triangle.vertices[1]));
+	idVertices[2]->setValues(IdFile::toVertex_s(triangle.vertices[2]));
+
+	idAccess[0]->setValue(access.a[0]);
+	idAccess[1]->setValue(access.a[1]);
+	idAccess[2]->setValue(access.a[2]);
+
+	walkmeshGL->setSelectedTriangle(i);
+}
+
+void WalkmeshWidget::addTriangle()
+{
+	int row = idList->currentRow();
+
+	if (data()->hasIdFile()) {
+		Triangle tri;
+		Access acc;
+		if (row < data()->getIdFile()->triangleCount()) {
+			tri = data()->getIdFile()->triangle(row);
+			acc = data()->getIdFile()->access(row);
+		} else {
+			tri = Triangle();
+			acc = Access();
+		}
+		data()->getIdFile()->insertTriangle(row+1, tri, acc);
+		idList->insertItem(row+1, tr("Triangle %1").arg(row+1));
+		for (int i = row + 2; i < idList->count(); ++i) {
+			idList->item(i)->setText(tr("Triangle %1").arg(i));
+		}
+		idList->setCurrentRow(row+1);
+		emit modified();
+	}
+}
+
+void WalkmeshWidget::removeTriangle()
+{
+	int row = idList->currentRow();
+
+	if (row < 0)		return;
+
+	if (data()->hasIdFile() && row < data()->getIdFile()->triangleCount()) {
+		data()->getIdFile()->removeTriangle(row);
+		delete idList->item(row);
+		for (int i = row; i < idList->count(); ++i) {
+			idList->item(i)->setText(tr("Triangle %1").arg(i));
+		}
+		setCurrentId(row);
+		emit modified();
+	}
+}
+
+void WalkmeshWidget::editIdTriangle(const Vertex &values)
+{
+	QObject *s = sender();
+
+	if (s == idVertices[0])			editIdTriangle(0, values);
+	else if (s == idVertices[1])		editIdTriangle(1, values);
+	else if (s == idVertices[2])		editIdTriangle(2, values);
+}
+
+void WalkmeshWidget::editIdTriangle(int id, const Vertex &values)
+{
+	if (data()->hasIdFile()) {
+		const int triangleID = idList->currentRow();
+		if (triangleID > -1 && triangleID < data()->getIdFile()->triangleCount()) {
+			Triangle old = data()->getIdFile()->triangle(triangleID);
+			Vertex_sr &oldV = old.vertices[id];
+			if (oldV.x != values.x || oldV.y != values.y || oldV.z != values.z) {
+				oldV = IdFile::fromVertex_s(values);
+				data()->getIdFile()->setTriangle(triangleID, old);
+				walkmeshGL->update();
+				emit modified();
+			}
+		}
+	}
+}
+
+void WalkmeshWidget::editIdAccess(int value)
+{
+	QObject *s = sender();
+
+	if (s == idAccess[0])			editIdAccess(0, value);
+	else if (s == idAccess[1])		editIdAccess(1, value);
+	else if (s == idAccess[2])		editIdAccess(2, value);
+}
+
+void WalkmeshWidget::editIdAccess(int id, int value)
+{
+	if (data()->hasIdFile()) {
+		const int triangleID = idList->currentRow();
+		if (triangleID > -1 && triangleID < data()->getIdFile()->triangleCount()) {
+			Access old = data()->getIdFile()->access(triangleID);
+			qint16 oldV = old.a[id];
+			if (oldV != value) {
+				old.a[id] = value;
+				data()->getIdFile()->setAccess(triangleID, old);
+				walkmeshGL->update();
+				emit modified();
+			}
+		}
+	}
+}
+
+void WalkmeshWidget::setCurrentGateway(int id)
+{
+	if (!data()->hasInfFile() || id < 0)    return;
+
+	InfFile *inf = data()->getInfFile();
+	if (12 <= id)    return;
+
+	const Gateway &gateway = inf->getGateway(id);
+
+	exitPoints[0]->setValues(gateway.exitLine[0]);
+	exitPoints[1]->setValues(gateway.exitLine[1]);
+	entryPoint->setValues(gateway.destinationPoint);
+	fieldId->setValue(gateway.fieldId);
+	unknownGate1[0]->setValue(gateway.unknown1[0]);
+	unknownGate1[1]->setValue(gateway.unknown1[1]);
+	unknownGate1[2]->setValue(gateway.unknown1[2]);
+	unknownGate1[3]->setValue(gateway.unknown1[3]);
+
+	unknownGate2->setData(QByteArray((char *)&gateway.unknown2, 4));
+
+	walkmeshGL->setSelectedGate(id);
+}
+
+void WalkmeshWidget::setCurrentDoor(int id)
+{
+	if (!data()->hasInfFile() || id < 0)    return;
+
+	InfFile *inf = data()->getInfFile();
+	if (12 <= id)    return;
+
+	const Trigger &trigger = inf->getTrigger(id);
+
+	doorPosition[0]->setValues(trigger.trigger_line[0]);
+	doorPosition[1]->setValues(trigger.trigger_line[1]);
+	if (trigger.doorID == 0xFF) {
+		doorId->setValue(0);
+		doorId->setEnabled(false);
+		doorUsed->setChecked(false);
+	} else {
+		doorId->setValue(trigger.doorID);
+		doorId->setEnabled(true);
+		doorUsed->setChecked(true);
+	}
+	walkmeshGL->setSelectedDoor(id);
+}
+
+void WalkmeshWidget::editExitPoint(const Vertex &values)
+{
+	QObject *s = sender();
+
+	if (s == exitPoints[0])			editExitPoint(0, values);
+	else if (s == exitPoints[1])		editExitPoint(1, values);
+}
+
+void WalkmeshWidget::editExitPoint(int id, const Vertex &values)
+{
+	if (data()->hasInfFile()) {
+		int gateId = gateList->currentRow();
+		Gateway old = data()->getInfFile()->getGateway(gateId);
+		Vertex oldVertex = old.exitLine[id];
+		if (oldVertex.x != values.x || oldVertex.y != values.y || oldVertex.z != values.z) {
+			old.exitLine[id] = values;
+			data()->getInfFile()->setGateway(gateId, old);
+			walkmeshGL->update();
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editEntryPoint(const Vertex &values)
+{
+	if (data()->hasInfFile()) {
+		int gateId = gateList->currentRow();
+		Gateway old = data()->getInfFile()->getGateway(gateId);
+		Vertex oldVertex = old.destinationPoint;
+		if (oldVertex.x != values.x || oldVertex.y != values.y || oldVertex.z != values.z) {
+			old.destinationPoint = values;
+			data()->getInfFile()->setGateway(gateId, old);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editDoorPoint(const Vertex &values)
+{
+	QObject *s = sender();
+
+	if (s == doorPosition[0])			editDoorPoint(0, values);
+	else if (s == doorPosition[1])		editDoorPoint(1, values);
+}
+
+void WalkmeshWidget::editDoorPoint(int id, const Vertex &values)
+{
+	if (data()->hasInfFile()) {
+		int gateId = gateList->currentRow();
+		Trigger old = data()->getInfFile()->getTrigger(gateId);
+		Vertex oldVertex = old.trigger_line[id];
+		if (oldVertex.x != values.x || oldVertex.y != values.y || oldVertex.z != values.z) {
+			old.trigger_line[id] = values;
+			data()->getInfFile()->setTrigger(gateId, old);
+			walkmeshGL->update();
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editUnknownGate(int val)
+{
+	QObject *s = sender();
+
+	if (s == unknownGate1[0])			editUnknownGate(0, val);
+	else if (s == unknownGate1[1])		editUnknownGate(1, val);
+	else if (s == unknownGate1[2])		editUnknownGate(2, val);
+	else if (s == unknownGate1[3])		editUnknownGate(3, val);
+}
+
+void WalkmeshWidget::editUnknownGate(int id, int val)
+{
+	if (data()->hasInfFile()) {
+		int gateId = gateList->currentRow();
+		Gateway old = data()->getInfFile()->getGateway(gateId);
+		if (old.unknown1[id] != val) {
+			old.unknown1[id] = val;
+			data()->getInfFile()->setGateway(gateId, old);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editUnknownGate(const QByteArray &u)
+{
+	if (data()->hasInfFile()) {
+		int gateId = gateList->currentRow();
+		const char *uData = u.constData();
+		Gateway old = data()->getInfFile()->getGateway(gateId);
+		memcpy(&old.unknown2, uData, 4);
+		if (old.unknown2 != data()->getInfFile()->getGateway(gateId).unknown2) {
+			data()->getInfFile()->setGateway(gateId, old);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editFieldId(int v)
+{
+	if (data()->hasInfFile()) {
+		int gateId = gateList->currentRow();
+		Gateway old = data()->getInfFile()->getGateway(gateId);
+		if (old.fieldId != v) {
+			old.fieldId = v;
+			data()->getInfFile()->setGateway(gateId, old);
+			if (v != 0x7FFF) {
+				gateList->currentItem()->setText(QString("%1 (%2)").arg(Data::maplist().value(v)).arg(v));
+			} else {
+				gateList->currentItem()->setText(tr("Unused"));
+			}
+
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editDoorUsed(bool enable)
+{
+	doorId->setEnabled(enable);
+
+	editDoorId(enable ? doorId->value() : 0xFF);
+}
+
+void WalkmeshWidget::editDoorId(int v)
+{
+	if (data()->hasInfFile()) {
+		int gateId = doorList->currentRow();
+		Trigger old = data()->getInfFile()->getTrigger(gateId);
+		v = doorUsed->isChecked() ? doorId->value() : 0xFF;
+		if (old.doorID != v) {
+			old.doorID = v;
+			data()->getInfFile()->setTrigger(gateId, old);
+			if (v != 0xFF) {
+				doorList->currentItem()->setText(tr("Door %1").arg(v));
+			} else {
+				doorList->currentItem()->setText(tr("Unused"));
+			}
+
+			walkmeshGL->update();
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::setCurrentRange1(int id)
+{
+	if (!data()->hasInfFile() || id < 0)    return;
+
+	InfFile *inf = data()->getInfFile();
+	if (8 <= id)    return;
+
+	const Range &range = inf->cameraRange(id);
+
+	rangeEdit1[0]->setValue(range.top);
+	rangeEdit1[1]->setValue(range.bottom);
+	rangeEdit1[2]->setValue(range.right);
+	rangeEdit1[3]->setValue(range.left);
+}
+
+void WalkmeshWidget::setCurrentRange2(int id)
+{
+	if (!data()->hasInfFile() || id < 0)    return;
+
+	InfFile *inf = data()->getInfFile();
+	if (2 <= id)    return;
+
+	const Range &range = inf->screenRange(id);
+
+	rangeEdit2[0]->setValue(range.top);
+	rangeEdit2[1]->setValue(range.bottom);
+	rangeEdit2[2]->setValue(range.right);
+	rangeEdit2[3]->setValue(range.left);
+}
+
+void WalkmeshWidget::editRange(int v)
+{
+	QObject *s = sender();
+
+	if (s == rangeEdit1[0])			editRange1(0, v);
+	else if (s == rangeEdit1[1])		editRange1(1, v);
+	else if (s == rangeEdit1[2])		editRange1(2, v);
+	else if (s == rangeEdit1[3])		editRange1(3, v);
+	else if (s == rangeEdit2[0])		editRange2(0, v);
+	else if (s == rangeEdit2[1])		editRange2(1, v);
+	else if (s == rangeEdit2[2])		editRange2(2, v);
+	else if (s == rangeEdit2[3])		editRange2(3, v);
+}
+
+void WalkmeshWidget::editRange1(int id, int v)
+{
+	if (data()->hasInfFile()) {
+		const int currentRange = rangeList1->currentRow();
+		Range old = data()->getInfFile()->cameraRange(currentRange);
+		qint16 oldv=0;
+
+		switch (id) {
+		case 0:	oldv = old.top;		break;
+		case 1:	oldv = old.bottom;	break;
+		case 2:	oldv = old.right;	break;
+		case 3:	oldv = old.left;	break;
+		}
+
+		if (oldv != v) {
+			switch (id) {
+			case 0:	old.top = v;	break;
+			case 1:	old.bottom = v;	break;
+			case 2:	old.right = v;	break;
+			case 3:	old.left = v;	break;
+			}
+			data()->getInfFile()->setCameraRange(currentRange, old);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editRange2(int id, int v)
+{
+	if (data()->hasInfFile()) {
+		const int currentRange = rangeList2->currentRow();
+		Range old = data()->getInfFile()->screenRange(currentRange);
+		qint16 oldv=0;
+
+		switch (id) {
+		case 0:	oldv = old.top;		break;
+		case 1:	oldv = old.bottom;	break;
+		case 2:	oldv = old.right;	break;
+		case 3:	oldv = old.left;	break;
+		}
+
+		if (oldv != v) {
+			switch (id) {
+			case 0:	old.top = v;	break;
+			case 1:	old.bottom = v;	break;
+			case 2:	old.right = v;	break;
+			case 3:	old.left = v;	break;
+			}
+			data()->getInfFile()->setScreenRange(currentRange, old);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::setCurrentMoviePosition(int id)
+{
+	if (!data()->hasMskFile() || id < 0) {
+		setMovieCameraPageEnabled(false);
+		return;
+	}
+
+	MskFile *msk = data()->getMskFile();
+	if (msk->cameraPositionCount() <= id) {
+		setMovieCameraPageEnabled(false);
+		return;
+	}
+
+	setMovieCameraPageEnabled(true);
+
+	camPoints[0]->setValues(msk->cameraPosition(id)[0]);
+	camPoints[1]->setValues(msk->cameraPosition(id)[1]);
+	camPoints[2]->setValues(msk->cameraPosition(id)[2]);
+	camPoints[3]->setValues(msk->cameraPosition(id)[3]);
+}
+
+void WalkmeshWidget::setMovieCameraPageEnabled(bool enabled)
+{
+	camPoints[0]->setEnabled(enabled);
+	camPoints[1]->setEnabled(enabled);
+	camPoints[2]->setEnabled(enabled);
+	camPoints[3]->setEnabled(enabled);
+}
+
+void WalkmeshWidget::addMovieCameraPosition()
+{
+	if (!data()->hasMskFile()) {
+		data()->addMskFile();
+	}
+
+	int row = frameList->currentRow();
+	if (row < 0)	row = 0;
+
+	Vertex *camPos = new Vertex[4];
+
+	memset(camPos, 0, sizeof(Vertex) * 4);
+
+	data()->getMskFile()->insertCameraPosition(row+1, camPos);
+
+	frameList->addItem(tr("Position %1").arg(row+1));
+	for (int i = row + 1; i < frameList->count(); ++i) {
+		frameList->item(i)->setText(tr("Position %1").arg(i+1));
+	}
+
+	emit modified();
+
+	frameList->setCurrentRow(row+1);
+}
+
+void WalkmeshWidget::removeMovieCameraPosition()
+{
+	if (!data()->hasMskFile()) {
+		data()->addMskFile();
+	}
+
+	int row = frameList->currentRow();
+	if (row < 0)	row = 0;
+
+	data()->getMskFile()->removeCameraPosition(row);
+
+	delete frameList->item(row);
+	for (int i = row; i < frameList->count(); ++i) {
+		frameList->item(i)->setText(tr("Position %1").arg(i+1));
+	}
+
+	emit modified();
+}
+
+void WalkmeshWidget::editNavigation(int v)
+{
+	if (data()->hasInfFile()) {
+		int old = data()->getInfFile()->controlDirection();
+		if (old != v) {
+			navigation->setValue(v);
+			data()->getInfFile()->setControlDirection(v);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editUnknown(const QByteArray &u)
+{
+	if (data()->hasInfFile()) {
+		if (u != data()->getInfFile()->unknown()) {
+			data()->getInfFile()->setUnknown(u);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::editCameraFocus(int value)
+{
+	if (data()->hasInfFile()) {
+		if (value != data()->getInfFile()->cameraFocusHeight()) {
+			data()->getInfFile()->setCameraFocusHeight(value);
+			emit modified();
+		}
+	}
+}
+
+void WalkmeshWidget::focusInEvent(QFocusEvent *e)
+{
+	if (isBuilded())	walkmeshGL->setFocus();
+	QWidget::focusInEvent(e);
+}
+
+void WalkmeshWidget::focusOutEvent(QFocusEvent *e)
+{
+	if (isBuilded())	walkmeshGL->clearFocus();
+	QWidget::focusOutEvent(e);
+}

--- a/src/widgets/gl/WalkmeshWidget.h
+++ b/src/widgets/gl/WalkmeshWidget.h
@@ -1,0 +1,131 @@
+/****************************************************************************
+ ** Deling Final Fantasy VIII Field Editor
+ ** Copyright (C) 2009-2024 Arzel Jérôme <myst6re@gmail.com>
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+#pragma once
+
+#include <QtWidgets>
+#include "widgets/PageWidget.h"
+#include "3d/WalkmeshGLWidget.h"
+#include "VertexWidget.h"
+#include "OrientationWidget.h"
+#include "HexLineEdit.h"
+
+class WalkmeshWidget : public PageWidget
+{
+	Q_OBJECT
+public:
+	WalkmeshWidget(QWidget *parent = nullptr);
+	void clear();
+	void setReadOnly(bool ro);
+	void fill();
+	inline QString tabName() const { return tr("Walkmesh"); }
+	int currentCamera() const;
+public slots:
+	void resetCamera();
+	void setCurrentCamera(int camID);
+private slots:
+	void addCamera();
+	void removeCamera();
+	void editCaVector(const Vertex &values);
+	void editCaPos(double value);
+	void editCaZoom(int value);
+	void setCurrentId(int i);
+	void addTriangle();
+	void removeTriangle();
+	void editIdTriangle(const Vertex &values);
+	void editIdAccess(int value);
+    void setCurrentGateway(int id);
+	void setCurrentDoor(int id);
+	void editExitPoint(const Vertex &values);
+	void editEntryPoint(const Vertex &values);
+	void editDoorPoint(const Vertex &values);
+	void editFieldId(int v);
+	void editDoorUsed(bool enable);
+	void editDoorId(int v);
+	void setCurrentRange1(int id);
+	void setCurrentRange2(int id);
+	void editRange(int v);
+	void editUnknownGate(int val);
+	void editUnknownGate(const QByteArray &u);
+    void setCurrentMoviePosition(int id);
+	void setMovieCameraPageEnabled(bool enabled);
+	void addMovieCameraPosition();
+	void removeMovieCameraPosition();
+	void editNavigation(int v);
+	void editUnknown(const QByteArray &u);
+	void editCameraFocus(int value);
+protected:
+	virtual void focusInEvent(QFocusEvent *e);
+	virtual void focusOutEvent(QFocusEvent *e);
+private:
+	void build();
+	QWidget *buildCameraPage();
+	QWidget *buildWalkmeshPage();
+	QWidget *buildGatewaysPage();
+	QWidget *buildDoorsPage();
+	QWidget *buildCameraRangePage();
+	QWidget *buildMovieCameraPage();
+	QWidget *buildMiscPage();
+	void editCaVector(int id, const Vertex &values);
+	void editCaPos(int id, double value);
+	void editIdTriangle(int id, const Vertex &values);
+	void editIdAccess(int id, int value);
+	void editExitPoint(int id, const Vertex &values);
+	void editDoorPoint(int id, const Vertex &values);
+	void editRange1(int id, int v);
+	void editRange2(int id, int v);
+	void editUnknownGate(int id, int val);
+
+	WalkmeshGLWidget *walkmeshGL;
+	QCheckBox *showBackground;
+	QSlider *slider1, *slider2, *slider3;
+	QTabWidget *tabWidget;
+	//CamPage
+	QToolBar *caToolbar;
+	QListWidget *camList;
+	VertexWidget *caVectorXEdit, *caVectorYEdit, *caVectorZEdit;
+	QDoubleSpinBox *caSpaceXEdit, *caSpaceYEdit, *caSpaceZEdit;
+	QSpinBox *caZoomEdit;
+	//WalkmeshPage
+	QToolBar *idToolbar;
+	QListWidget *idList;
+	VertexWidget *idVertices[3];
+	QSpinBox *idAccess[3];
+	//GatePage
+	QListWidget *gateList;
+	HexLineEdit *unknownGate2;
+	QSpinBox *unknownGate1[4], *fieldId;
+	VertexWidget *exitPoints[2], *entryPoint;
+	//DoorPage
+	QListWidget *doorList;
+	QCheckBox *doorUsed;
+	QSpinBox *doorId;
+	VertexWidget *doorPosition[2];
+	//CameraRangePage
+	QListWidget *rangeList1, *rangeList2;
+	QSpinBox *rangeEdit1[4], *rangeEdit2[4];
+	//MovieCamPage
+	QListWidget *frameList;
+	QToolBar *camToolbar;
+	QAction *camPlusAction, *camMinusAction;
+    VertexWidget *camPoints[4];
+	//MiscPage
+	OrientationWidget *navigation;
+	QSpinBox *navigation2;
+	HexLineEdit *unknown;
+	QSpinBox *cameraFocus;
+};

--- a/src/widgets/gl/WorldmapWidget.cpp
+++ b/src/widgets/gl/WorldmapWidget.cpp
@@ -15,7 +15,6 @@
  ** You should have received a copy of the GNU General Public License
  ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
  ****************************************************************************/
-
 #include "WorldmapWidget.h"
 #include "Field.h"
 
@@ -30,7 +29,7 @@ void WorldmapWidget::build()
 		return;
 	}
 	
-	_scene = new WorldmapRenderWidget(this);
+	_scene = new WorldmapGLWidget(this);
 	const int minRot = -360, maxRot = 360;
 	
 	_xRotSlider = new QSlider(Qt::Vertical, this);

--- a/src/widgets/gl/WorldmapWidget.h
+++ b/src/widgets/gl/WorldmapWidget.h
@@ -17,12 +17,8 @@
  ****************************************************************************/
 #pragma once
 
-#ifdef USE_OPENGL
-#include "gl/WorldmapWidget.h"
-#else
-
 #include <QtWidgets>
-#include "widgets/WorldmapRenderWidget.h"
+#include "3d/WorldmapGLWidget.h"
 #include "widgets/PageWidget.h"
 
 class WorldmapWidget : public PageWidget
@@ -30,7 +26,7 @@ class WorldmapWidget : public PageWidget
 	Q_OBJECT
 public:
 	explicit WorldmapWidget(QWidget *parent = nullptr);
-	inline WorldmapRenderWidget *scene() const {
+	inline WorldmapGLWidget *scene() const {
 		return _scene;
 	}
 	void fill() override;
@@ -43,7 +39,6 @@ private slots:
 	void resetCamera();
 private:
 	void build() override;
-	WorldmapRenderWidget *_scene;
+	WorldmapGLWidget *_scene;
 	QSlider *_xRotSlider, *_yRotSlider, *_zRotSlider;
 };
-#endif


### PR DESCRIPTION
### Changes
- Port to QRhi
- Added `RHI` option to CMake, on by default. Setting it to `OFF` will build the old version using QOpenGLWidgets and will define `USE_OPENGL` in the code
- Moved support to C++20
- Add support for [CCache](https://ccache.dev/)
- Autobuild shaders for QRhi
- Fix warnings ([1](https://github.com/Kidev/deling/pull/5/files#diff-6ca39b2523b2b1a8497a1db48d0844aaa1a26f2bd261c73bc7532c39e718afc5) [2](https://github.com/Kidev/deling/pull/5/files#diff-ce98c2b7ee1193fbaef3e184df63fe70d229d9489daa6ed06a2688a5cb157673) [3](https://github.com/Kidev/deling/pull/5/files#diff-35daa5275cc07152d7ff42fe5733371f7ae3c1d039bd39c666b496d05b68156b) [4](https://github.com/Kidev/deling/pull/5/files#diff-31025099fdc5cf47eae1a38a38a230ff4aaf8d5d47227678944088a819cf0276) [5](https://github.com/Kidev/deling/pull/5/files#diff-0190794200f7c41777560de92df62318c3787a9d46b5f6c5febe8202fcb7fc05) [6](https://github.com/Kidev/deling/pull/5/files#diff-f0df8e5a5da1260baaad6408b5d9ec4548e1b9ed1e15ed021d30d61358548974))       
- Fixed the overwriting of orange edges by accumulating edges before rendering them (so that the rest of the mesh does not rewrite an orange edge into a white one, and the edges are displayed cyan based on position at loading it is not recomputed after)
- Make the squares marking selection of a door/exit only visible in the relevant tab (the triangles are not affected)

### Notes
- Builds fine for all (even for Debian that compiles with `RHI=OFF` and uses QOpenGLWidgets)
- `WorldmapRenderWidget` is not really implemented, only enough to make it compile
- All native graphic resources are returned to the kernel, no leaks
- The changes in `main.cpp` enable a HUGE amount of graphic logs in `Debug` mode
- All the files in `src/3d/` are untouched
- `WorldmapWidget` and `WalkmeshWidget` related files were moved to `src/widgets/gl` for the legacy version, the files that remain where they were are now only used for redirect in the legacy version, and as the main files for the QRhi version
<details><summary><b>Details on how the seamless port works</b></summary>

  ```cpp
// File: src/widgets/WorldmapWidget.h
#ifdef USE_OPENGL
#include "gl/WorldmapWidget.h" // (src/widgets/gl/WorldmapWidget.h)
#else

#include <QtWidgets>
#include "widgets/WorldmapRenderWidget.h"
#include "widgets/PageWidget.h"

class WorldmapWidget : public PageWidget
{
// ...
};

#endif
  ```

</details>

